### PR TITLE
Portability pass, in preparation for a Windows build

### DIFF
--- a/src/alsa_midi.cpp
+++ b/src/alsa_midi.cpp
@@ -13,18 +13,59 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef MIDI_ALSA
+
 #include "alsa_midi.h"
 #include <format>
 #include <print>
 #include <alsa/asoundlib.h>
 
 
-static snd_seq_t *SeqHandle = nullptr;
-static int MidiInPort = -1;
-static int MidiOutPort = -1;
+AlsaMidiDriver::AlsaMidiDriver()
+{
+    if (snd_seq_open(&SeqHandle, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK) == 0)
+    {
+        snd_seq_set_client_name(SeqHandle, "mollytime");
+        {
+            const unsigned int Caps = SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE;
+            const unsigned int Type = SND_SEQ_PORT_TYPE_APPLICATION | SND_SEQ_PORT_TYPE_SOFTWARE | SND_SEQ_PORT_TYPE_SYNTHESIZER;
+            MidiInPort = snd_seq_create_simple_port(SeqHandle, "in", Caps, Type);
+        }
+        {
+            const unsigned int Caps = SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ;
+            const unsigned int Type = SND_SEQ_PORT_TYPE_APPLICATION | SND_SEQ_PORT_TYPE_SOFTWARE;
+            MidiOutPort = snd_seq_create_simple_port(SeqHandle, "out", Caps, Type);
+        }
+    }
+    else
+    {
+        std::print("Unable to initialize ALSA.  No MIDI connections will be possible.\n");
+        SeqHandle = nullptr;
+    }
+}
 
 
-void Midi::ProcessEvents(MidiHandler* Handler)
+AlsaMidiDriver::~AlsaMidiDriver()
+{
+    if (SeqHandle)
+    {
+        if (MidiOutPort > -1)
+        {
+            snd_seq_delete_simple_port(SeqHandle, MidiOutPort);
+            MidiOutPort = -1;
+        }
+        if (MidiInPort > -1)
+        {
+            snd_seq_delete_simple_port(SeqHandle, MidiInPort);
+            MidiInPort = -1;
+        }
+        snd_seq_close(SeqHandle);
+        SeqHandle = nullptr;
+    }
+}
+
+
+void AlsaMidiDriver::ProcessEvents(MidiHandler* Handler)
 {
     snd_seq_event_t* Event = nullptr;
     if (SeqHandle)
@@ -50,46 +91,4 @@ void Midi::ProcessEvents(MidiHandler* Handler)
     }
 }
 
-
-void Midi::Init()
-{
-    if (snd_seq_open(&SeqHandle, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK) == 0)
-    {
-        snd_seq_set_client_name(SeqHandle, "mollytime");
-        {
-            const unsigned int Caps = SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE;
-            const unsigned int Type = SND_SEQ_PORT_TYPE_APPLICATION | SND_SEQ_PORT_TYPE_SOFTWARE | SND_SEQ_PORT_TYPE_SYNTHESIZER;
-            MidiInPort = snd_seq_create_simple_port(SeqHandle, "in", Caps, Type);
-        }
-        {
-            const unsigned int Caps = SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ;
-            const unsigned int Type = SND_SEQ_PORT_TYPE_APPLICATION | SND_SEQ_PORT_TYPE_SOFTWARE;
-            MidiOutPort = snd_seq_create_simple_port(SeqHandle, "out", Caps, Type);
-        }
-    }
-    else
-    {
-        std::print("Unable to initialize ALSA.  No MIDI connections will be possible.\n");
-        SeqHandle = nullptr;
-    }
-}
-
-
-void Midi::Shutdown()
-{
-    if (SeqHandle)
-    {
-        if (MidiOutPort > -1)
-        {
-            snd_seq_delete_simple_port(SeqHandle, MidiOutPort);
-            MidiOutPort = -1;
-        }
-        if (MidiInPort > -1)
-        {
-            snd_seq_delete_simple_port(SeqHandle, MidiInPort);
-            MidiInPort = -1;
-        }
-        snd_seq_close(SeqHandle);
-        SeqHandle = nullptr;
-    }
-}
+#endif

--- a/src/alsa_midi.h
+++ b/src/alsa_midi.h
@@ -17,11 +17,11 @@
 
 #include "midi.h"
 
-struct snd_seq_t;
+struct _snd_seq;
 
 class AlsaMidiDriver final : public MidiDriver
 {
-    snd_seq_t *SeqHandle = nullptr;
+    struct _snd_seq *SeqHandle = nullptr;
     int MidiInPort = -1;
     int MidiOutPort = -1;
 

--- a/src/alsa_midi.h
+++ b/src/alsa_midi.h
@@ -17,7 +17,7 @@
 
 #include "midi.h"
 
-struct _snd_seq;
+struct _snd_seq;    // Forward declares `typedef struct _snd_seq snd_seq_t` from <alsa/seq.h>.
 
 class AlsaMidiDriver final : public MidiDriver
 {

--- a/src/audio_backend.cpp
+++ b/src/audio_backend.cpp
@@ -14,6 +14,13 @@
 // limitations under the License.
 
 #include "audio_backend.h"
+#include "jack_stream.h"
+
+#include <memory>
+#include <print>
+
+
+static std::unique_ptr<AudioStream> Stream;
 
 
 void RealTimeAudioThread::ResetFramePressure()
@@ -116,15 +123,9 @@ void RealTimeAudioThread::AdvanceFrames(FramePointers& Frame)
     LastFrameStart = FrameStart;
 }
 
-// ---
 
-#include "jack_stream.h"
-
-#include <memory>
-
-static std::unique_ptr<AudioStream> Stream;
-
-
+// This no-op stub is used if no AudioStream is available.
+// It's quite possible the program should just crash, instead. What use is an audio generator with no audio?
 struct StubStream final : AudioStream
 {
     virtual float GetTemporalPressure() override { return 0.0f; }
@@ -143,6 +144,7 @@ void Audio::Init(int SampleRate)
 #ifdef ENABLE_JACK
     Stream = std::make_unique<JackStream>(SampleRate);
 #else
+    std::println("No audio stream implementation is available.");
     Stream = std::make_unique<StubStream>();
 #endif
 }

--- a/src/audio_backend.cpp
+++ b/src/audio_backend.cpp
@@ -100,7 +100,7 @@ void RealTimeAudioThread::AdvanceFrames(FramePointers& Frame)
 
     FramePressureCount = std::max(FramePressureIndex, FramePressureCount);
     FramePressureIndex %= FramePressure.size();
-    if (Program && FramePressureCount == FramePressure.size())
+    if (Program && FramePressureCount == static_cast<int>(FramePressure.size()))
     {
         TemporalPressure = FramePressure[0];
         for (int Index = 1; Index < FramePressureCount; ++Index)

--- a/src/audio_backend.cpp
+++ b/src/audio_backend.cpp
@@ -115,3 +115,54 @@ void RealTimeAudioThread::AdvanceFrames(FramePointers& Frame)
     }
     LastFrameStart = FrameStart;
 }
+
+// ---
+
+#include "jack_stream.h"
+
+#include <memory>
+
+static std::unique_ptr<AudioStream> Stream;
+
+
+struct StubStream final : AudioStream
+{
+    virtual float GetTemporalPressure() override { return 0.0f; }
+    virtual void ProgramChange(ScratchSharedPtr& NewProgram) override {}
+};
+
+
+AudioStream* Audio::GetStream()
+{
+    return Stream.get();
+}
+
+
+void Audio::Init(int SampleRate)
+{
+#ifdef ENABLE_JACK
+    Stream = std::make_unique<JackStream>(SampleRate);
+#else
+    Stream = std::make_unique<StubStream>();
+#endif
+}
+
+
+void Audio::Shutdown()
+{
+    if(Stream)
+    {
+        Stream.reset();
+    }
+}
+
+
+float Audio::GetTemporalPressure()
+{
+    if(!Stream)
+    {
+        return 0.0f;
+    }
+    
+    return Stream->GetTemporalPressure();
+}

--- a/src/audio_backend.h
+++ b/src/audio_backend.h
@@ -74,13 +74,18 @@ protected:
 
 struct AudioStream
 {
-    static AudioStream* Get();
-    static void Init(int SampleRate);
-    static void Shutdown();
-    static float GetTemporalPressure();
+    virtual ~AudioStream() {}
 
-    virtual float GetTemporalPressureInner() = 0;
+    virtual float GetTemporalPressure() = 0;
     virtual void ProgramChange(ScratchSharedPtr& NewProgram) = 0;
+};
 
-    virtual ~AudioStream() {};
+
+namespace Audio
+{
+    AudioStream* GetStream();
+
+    void Init(int SampleRate);
+    void Shutdown();
+    float GetTemporalPressure();
 };

--- a/src/audio_backend.h
+++ b/src/audio_backend.h
@@ -40,7 +40,7 @@ struct AudioThreadShared
 
 struct FramePointers
 {
-    size_t SampleCount = 0;
+    int SampleCount = 0;
     float* OutLeft = nullptr;
     float* OutRight = nullptr;
     std::vector<std::tuple<float*, double*>> InPtrs;

--- a/src/audio_backend.h
+++ b/src/audio_backend.h
@@ -62,6 +62,8 @@ protected:
     int FramePressureIndex = 0;
     int FramePressureCount = 0;
 
+    virtual ~RealTimeAudioThread() {}
+
     virtual void BeginFrame(FramePointers& Frame) = 0;
     virtual void EndFrame(FramePointers& Frame) {};
 

--- a/src/colors.cpp
+++ b/src/colors.cpp
@@ -311,7 +311,7 @@ static glm::vec3 sRGB2HSL(glm::vec3 sRGB)
 				Hue = (sRGB.r - sRGB.g) / D + 4.0f;
 			}
 
-			Hue = Hue * 60.0;
+			Hue = Hue * 60.0f;
 		}
 	}
 

--- a/src/colors.cpp
+++ b/src/colors.cpp
@@ -1035,6 +1035,6 @@ StatusCode ParseColor(std::string ColorString, glm::vec3& OutColor)
 ColorPoint ParseColor(std::string ColorString)
 {
 	ColorPoint ParsedColor = ColorPoint();
-	StatusCode Result = ParseColor(ColorString, ParsedColor);
+	ParseColor(ColorString, ParsedColor);
 	return ParsedColor;
 }

--- a/src/colors.cpp
+++ b/src/colors.cpp
@@ -36,7 +36,7 @@ const std::array<std::pair<ColorSpace, std::string>, size_t(ColorSpace::Count) >
 
 std::string ColorSpaceName(ColorSpace Encoding)
 {
-	for (int i = 0; i < size_t(ColorSpace::Count) ; ++i)
+	for (int i = 0; i < static_cast<int>(ColorSpace::Count); ++i)
 	{
 		if (EncodingNames[i].first == Encoding)
 		{
@@ -49,7 +49,7 @@ std::string ColorSpaceName(ColorSpace Encoding)
 
 bool FindColorSpace(std::string Name, ColorSpace& OutEncoding)
 {
-	for (int i = 0; i < size_t(ColorSpace::Count); ++i)
+	for (int i = 0; i < static_cast<int>(ColorSpace::Count); ++i)
 	{
 		if (EncodingNames[i].second == Name)
 		{

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -22,7 +22,15 @@
 
 // Requires package `boost-stacktrace` on Fedora
 // see also: https://www.boost.org/doc/libs/1_88_0/doc/html/stacktrace.html
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma warning(push)
+#pragma warning(disable : 4668 5039)
 #include <boost/stacktrace.hpp>
+#pragma warning(pop)
+#pragma clang diagnostic pop
 #endif
 
 

--- a/src/glm_common.h
+++ b/src/glm_common.h
@@ -26,6 +26,11 @@
 #define GLM_FORCE_INTRINSICS
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma warning(push)
+#pragma warning(disable : 4201 4464)
 #include <glm/vec3.hpp>
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>
@@ -33,6 +38,8 @@
 #include <glm/ext/matrix_clip_space.hpp>
 #include <glm/gtx/extended_min_max.hpp>
 #include <glm/gtx/quaternion.hpp>
+#pragma warning(pop)
+#pragma clang diagnostic pop
 
 
 // These are to patch over some differences between glsl and glm.

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -1,73 +1,15 @@
-
-// Copyright 2025 Aeva Palecek
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #ifdef ENABLE_JACK
 
-#include <vector>
-#include <mutex>
-#include <print>
-#include <format>
-//#include <cstring>
-#include <string>
+#include "audio_backend.h"
+#include "jack_stream.h"
 
-#include <signal.h>
-#ifndef WIN32
-#include <unistd.h>
-#endif
 #include <jack/jack.h>
 
-#include "audio_backend.h"
-#include "perf.h"
 
-static bool JackInitialized = false;
-static AudioStream* StreamSingleton = nullptr;
-static jack_client_t* JackClient;
-static const char* ClientName = "mollytime";
+// ---
 
 
-void JackShutdown(void* UserData = nullptr)
-{
-    if (JackInitialized)
-    {
-        JackInitialized = false;
-        jack_client_close(JackClient);
-    }
-}
-
-
-struct JackThreadShared : AudioThreadShared
-{
-    std::vector<jack_port_t*> OutputPorts;
-    std::map<TileHandle, jack_port_t*> InputPorts;
-    std::map<TileHandle, jack_port_t*> AuxOutPorts;
-};
-
-
-struct JackRealTimeThread : RealTimeAudioThread
-{
-    void Setup(JackThreadShared* InBufferState, int SampleRate);
-
-    static int OnProcess(jack_nframes_t FrameCount, void *UserData);
-
-private:
-    int OnProcessInner(jack_nframes_t FrameCount);
-    virtual void BeginFrame(FramePointers& Frame) override;
-};
-
-
-void JackRealTimeThread::Setup(JackThreadShared* JackBufferState, int SampleRate)
+JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShared* JackBufferState, int SampleRate)
 {
     BufferState = JackBufferState;
     SampleInterval = 1.0 / double(SampleRate);
@@ -86,21 +28,18 @@ void JackRealTimeThread::Setup(JackThreadShared* JackBufferState, int SampleRate
     {
         if (Port == nullptr)
         {
-            JackShutdown();
             throw std::runtime_error("Unable to create jack ports!\n");
         }
     }
 
     if (jack_activate(JackClient))
     {
-        JackShutdown();
         throw std::runtime_error("Unable to activate jack client!\n");
     }
 
     const char** Ports = jack_get_ports(JackClient, nullptr, nullptr, JackPortIsPhysical|JackPortIsInput);
     if (Ports == nullptr)
     {
-        JackShutdown();
         throw std::runtime_error("No physical playback ports!\n");
     }
 
@@ -117,14 +56,14 @@ void JackRealTimeThread::Setup(JackThreadShared* JackBufferState, int SampleRate
 }
 
 
-int JackRealTimeThread::OnProcess(jack_nframes_t FrameCount, void *UserData)
+int JackRealTimeThread::OnProcess(uint32_t FrameCount, void *UserData)
 {
     JackRealTimeThread* RealTimeThread = (JackRealTimeThread*)UserData;
     return RealTimeThread->OnProcessInner(FrameCount);
 }
 
 
-int JackRealTimeThread::OnProcessInner(jack_nframes_t FrameCount)
+int JackRealTimeThread::OnProcessInner(uint32_t FrameCount)
 {
     static_assert(std::is_same_v<float, jack_default_audio_sample_t>);
     TRACEABLE_SCOPE;
@@ -162,37 +101,50 @@ void JackRealTimeThread::BeginFrame(FramePointers& Frame)
 }
 
 
-struct JackStream : public AudioStream
+// ---
+
+
+static jack_client_t* OpenJackClient(const char*& ClientName)
 {
-    JackStream();
-    void Setup(int SampleRate);
-    virtual float GetTemporalPressureInner() override;
-    virtual void ProgramChange(ScratchSharedPtr& NewProgram) override;
-    virtual ~JackStream();
+    jack_status_t JackStatus;
+    jack_options_t JackOptions = JackNoStartServer;
+    jack_client_t* JackClient = jack_client_open(ClientName, JackOptions, &JackStatus, nullptr);
+    if (JackClient == nullptr)
+    {
+        throw std::runtime_error(std::format("jack_client_open() failed, jack status = {}\n", (int)JackStatus));
+    }
+    if (JackStatus & JackNameNotUnique)
+    {
+        ClientName = jack_get_client_name(JackClient);
+    }
 
-private:
-    JackRealTimeThread RealTimeThread;
-    JackThreadShared BufferState;
-};
-
-
-JackStream::JackStream()
-{
-    jack_set_process_callback(JackClient, JackRealTimeThread::OnProcess, &RealTimeThread);
-    jack_on_shutdown(JackClient, JackShutdown, 0);
+    return JackClient;
 }
 
 
-float JackStream::GetTemporalPressureInner()
+JackStream::JackStream(int SampleRate) :
+    JackClient(OpenJackClient(ClientName)),
+    RealTimeThread(JackClient, &BufferState, SampleRate)
+{
+    static_assert(std::is_same_v<jack_nframes_t, uint32_t>);
+    jack_set_process_callback(JackClient, JackRealTimeThread::OnProcess, &RealTimeThread);
+}
+
+
+JackStream::~JackStream()
+{
+    if(JackClient != nullptr)
+    {
+        jack_client_close(JackClient);
+        JackClient = nullptr;
+    }
+}
+
+
+float JackStream::GetTemporalPressure()
 {
     TRACEABLE_SCOPE;
     return BufferState.TemporalPressure.load();
-}
-
-
-void JackStream::Setup(int SampleRate)
-{
-    RealTimeThread.Setup(&BufferState, SampleRate);
 }
 
 
@@ -268,62 +220,4 @@ void JackStream::ProgramChange(ScratchSharedPtr& NewProgram)
     }
 }
 
-
-JackStream::~JackStream()
-{
-}
-
-
-AudioStream* AudioStream::Get()
-{
-    if (!JackInitialized)
-    {
-        JackInitialized = true;
-
-        jack_status_t JackStatus;
-        jack_options_t JackOptions = JackNoStartServer;
-        JackClient = jack_client_open(ClientName, JackOptions, &JackStatus, nullptr);
-        if (JackClient == nullptr)
-        {
-            throw std::runtime_error(std::format("jack_client_open() failed, jack status = {}\n", (int)JackStatus));
-        }
-        if (JackStatus & JackNameNotUnique)
-        {
-            ClientName = jack_get_client_name(JackClient);
-        }
-    }
-    if (StreamSingleton == nullptr)
-    {
-        StreamSingleton = new JackStream();
-    }
-    return StreamSingleton;
-}
-
-
-void AudioStream::Init(int SampleRate)
-{
-    TRACEABLE_SCOPE;
-    JackStream* JackSingleton = (JackStream*)Get();
-    JackSingleton->Setup(SampleRate);
-}
-
-
-void AudioStream::Shutdown()
-{
-    TRACEABLE_SCOPE;
-    if (StreamSingleton != nullptr)
-    {
-        delete StreamSingleton;
-        StreamSingleton = nullptr;
-    }
-    JackShutdown();
-}
-
-
-float AudioStream::GetTemporalPressure()
-{
-    return Get()->GetTemporalPressureInner();
-}
-
-
-#endif // ENABLE_JACK
+#endif

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -21,19 +21,32 @@ JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShar
     std::println("buffer staté is good");
 
     BufferState = JackBufferState;
+    std::println("assigned buffer staté");
+
     SampleInterval = 1.0 / double(SampleRate);
+    std::println("calculated sample interval");
+
     ResetFramePressure();
+    std::println("reset frame pressure");
 
     JackBufferState->OutputPorts.clear();
+    std::println("cleared output ports");
+
     JackBufferState->OutputPorts.resize(2, nullptr);
+    std::println("prepared 2 output ports");
 
     JackBufferState->OutputPorts[0] = jack_port_register(
         JackClient, "output_FL", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+    std::println("registered output port 0");
+
     assert(JackBufferState->OutputPorts[0] != nullptr);
     std::println("port 0 is good");
 
     JackBufferState->OutputPorts[1] = jack_port_register(
         JackClient, "output_FR", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+    std::println("registered output port 1");
+
+    assert(JackBufferState->OutputPorts[1] != nullptr);
     std::println("port 1 is good");
 
     for (jack_port_t* Port : JackBufferState->OutputPorts)

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -3,6 +3,9 @@
 #include "audio_backend.h"
 #include "jack_stream.h"
 
+#include <cassert>
+#include <print>
+
 #include <jack/jack.h>
 
 
@@ -11,6 +14,12 @@
 
 JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShared* JackBufferState, int SampleRate)
 {
+    assert(JackClient != nullptr);
+    std::println("jack client is good");
+
+    assert(JackBufferState != nullptr);
+    std::println("buffer staté is good");
+
     BufferState = JackBufferState;
     SampleInterval = 1.0 / double(SampleRate);
     ResetFramePressure();
@@ -20,9 +29,12 @@ JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShar
 
     JackBufferState->OutputPorts[0] = jack_port_register(
         JackClient, "output_FL", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+    assert(JackBufferState->OutputPorts[0] != nullptr);
+    std::println("port 0 is good");
 
     JackBufferState->OutputPorts[1] = jack_port_register(
         JackClient, "output_FR", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+    std::println("port 1 is good");
 
     for (jack_port_t* Port : JackBufferState->OutputPorts)
     {

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -1,3 +1,18 @@
+
+// Copyright 2025 Aeva Palecek
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifdef ENABLE_JACK
 
 #include "audio_backend.h"

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -23,8 +23,13 @@
 
 #include <jack/jack.h>
 
+static int OnProcess(jack_nframes_t FrameCount, void *UserData)
+{
+    assert(UserData != nullptr);
 
-// ---
+    JackRealTimeThread* RealTimeThread = (JackRealTimeThread*)UserData;
+    return RealTimeThread->OnProcess(static_cast<size_t>(FrameCount));
+}
 
 
 JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShared* JackBufferState, int SampleRate)
@@ -96,14 +101,7 @@ JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShar
 }
 
 
-int JackRealTimeThread::OnProcess(uint32_t FrameCount, void *UserData)
-{
-    JackRealTimeThread* RealTimeThread = (JackRealTimeThread*)UserData;
-    return RealTimeThread->OnProcessInner(FrameCount);
-}
-
-
-int JackRealTimeThread::OnProcessInner(uint32_t FrameCount)
+int JackRealTimeThread::OnProcess(size_t FrameCount)
 {
     static_assert(std::is_same_v<float, jack_default_audio_sample_t>);
     TRACEABLE_SCOPE;
@@ -159,7 +157,7 @@ static jack_client_t* OpenJackClient(const char*& ClientName, JackRealTimeThread
     }
 
     static_assert(std::is_same_v<jack_nframes_t, uint32_t>);
-    jack_set_process_callback(JackClient, JackRealTimeThread::OnProcess, &RealTimeThread);
+    jack_set_process_callback(JackClient, OnProcess, &RealTimeThread);
 
     return JackClient;
 }

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -19,7 +19,6 @@
 #include "jack_stream.h"
 
 #include <cassert>
-#include <print>
 
 #include <jack/jack.h>
 
@@ -35,39 +34,21 @@ static int OnProcess(jack_nframes_t FrameCount, void *UserData)
 JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShared* JackBufferState, int SampleRate)
 {
     assert(JackClient != nullptr);
-    std::println("jack client is good");
-
     assert(JackBufferState != nullptr);
-    std::println("buffer staté is good");
 
     BufferState = JackBufferState;
-    std::println("assigned buffer staté");
-
     SampleInterval = 1.0 / double(SampleRate);
-    std::println("calculated sample interval");
 
     ResetFramePressure();
-    std::println("reset frame pressure");
 
     JackBufferState->OutputPorts.clear();
-    std::println("cleared output ports");
-
     JackBufferState->OutputPorts.resize(2, nullptr);
-    std::println("prepared 2 output ports");
 
     JackBufferState->OutputPorts[0] = jack_port_register(
         JackClient, "output_FL", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
-    std::println("registered output port 0");
-
-    assert(JackBufferState->OutputPorts[0] != nullptr);
-    std::println("port 0 is good");
 
     JackBufferState->OutputPorts[1] = jack_port_register(
         JackClient, "output_FR", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
-    std::println("registered output port 1");
-
-    assert(JackBufferState->OutputPorts[1] != nullptr);
-    std::println("port 1 is good");
 
     for (jack_port_t* Port : JackBufferState->OutputPorts)
     {

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -31,54 +31,15 @@ static int OnProcess(jack_nframes_t FrameCount, void *UserData)
 }
 
 
-JackRealTimeThread::JackRealTimeThread(jack_client_t* JackClient, JackThreadShared* JackBufferState, int SampleRate)
+JackRealTimeThread::JackRealTimeThread(JackThreadShared* JackBufferState, int SampleRate)
 {
-    assert(JackClient != nullptr);
     assert(JackBufferState != nullptr);
+    assert(SampleRate != 0);
 
     BufferState = JackBufferState;
     SampleInterval = 1.0 / double(SampleRate);
 
     ResetFramePressure();
-
-    JackBufferState->OutputPorts.clear();
-    JackBufferState->OutputPorts.resize(2, nullptr);
-
-    JackBufferState->OutputPorts[0] = jack_port_register(
-        JackClient, "output_FL", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
-
-    JackBufferState->OutputPorts[1] = jack_port_register(
-        JackClient, "output_FR", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
-
-    for (jack_port_t* Port : JackBufferState->OutputPorts)
-    {
-        if (Port == nullptr)
-        {
-            throw std::runtime_error("Unable to create jack ports!\n");
-        }
-    }
-
-    if (jack_activate(JackClient))
-    {
-        throw std::runtime_error("Unable to activate jack client!\n");
-    }
-
-    const char** Ports = jack_get_ports(JackClient, nullptr, nullptr, JackPortIsPhysical|JackPortIsInput);
-    if (Ports == nullptr)
-    {
-        throw std::runtime_error("No physical playback ports!\n");
-    }
-
-    for (int PortIndex = 0; Ports[PortIndex] != nullptr && PortIndex < 2; ++PortIndex)
-    {
-        const char* ProgramOut = jack_port_name(JackBufferState->OutputPorts[PortIndex]);
-        if (jack_connect(JackClient, ProgramOut, Ports[PortIndex]))
-        {
-            // unable to connect to physical port
-        }
-    }
-
-    jack_free(Ports);
 }
 
 
@@ -120,11 +81,14 @@ void JackRealTimeThread::BeginFrame(FramePointers& Frame)
 }
 
 
-// ---
-
-
-static jack_client_t* OpenJackClient(const char*& ClientName, JackRealTimeThread& RealTimeThread)
+JackStream::JackStream(int SampleRate) :
+    JackClient(),
+    BufferState(),
+    RealTimeThread(&BufferState, SampleRate)
 {
+    TRACEABLE_SCOPE;
+
+    // First, open a Jack client.
     jack_status_t JackStatus;
     jack_options_t JackOptions = JackNoStartServer;
     jack_client_t* JackClient = jack_client_open(ClientName, JackOptions, &JackStatus, nullptr);
@@ -135,20 +99,61 @@ static jack_client_t* OpenJackClient(const char*& ClientName, JackRealTimeThread
     if (JackStatus & JackNameNotUnique)
     {
         ClientName = jack_get_client_name(JackClient);
+        assert(ClientName != nullptr);
     }
 
-    static_assert(std::is_same_v<jack_nframes_t, uint32_t>);
-    jack_set_process_callback(JackClient, OnProcess, &RealTimeThread);
+    // Then, register a process callback. We *must* do this now, before anything else.
+    int process_callback_status = jack_set_process_callback(JackClient, OnProcess, &RealTimeThread);
+    if(process_callback_status != 0)
+    {
+        throw std::runtime_error(std::format("jack_set_process_callback() failed, error code = {}\n", process_callback_status));
+    }
+    
+    // Now that that's taken care of, we can register output ports...
+    BufferState.OutputPorts.clear();
+    BufferState.OutputPorts.resize(2, nullptr);
 
-    return JackClient;
+    BufferState.OutputPorts[0] = jack_port_register(
+        JackClient, "output_FL", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+
+    BufferState.OutputPorts[1] = jack_port_register(
+        JackClient, "output_FR", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+
+    for (jack_port_t* Port : BufferState.OutputPorts)
+    {
+        if (Port == nullptr)
+        {
+            throw std::runtime_error("Unable to create jack ports!\n");
+        }
+    }
+
+    // ...Signal that we're ready to start processing...
+    if (jack_activate(JackClient))
+    {
+        throw std::runtime_error("Unable to activate jack client!\n");
+    }
+
+    // ...And conenct to the registered output ports.
+    const char** Ports = jack_get_ports(JackClient, nullptr, nullptr, JackPortIsPhysical|JackPortIsInput);
+    if (Ports == nullptr)
+    {
+        throw std::runtime_error("No physical playback ports!\n");
+    }
+
+    for (int PortIndex = 0; Ports[PortIndex] != nullptr && PortIndex < 2; ++PortIndex)
+    {
+        const char* ProgramOut = jack_port_name(BufferState.OutputPorts[PortIndex]);
+        assert(ProgramOut != nullptr);
+        
+        if (jack_connect(JackClient, ProgramOut, Ports[PortIndex]))
+        {
+            // unable to connect to physical port
+        }
+    }
+
+    // Now that we're connected, we can free the temporary Ports array.
+    jack_free(Ports);
 }
-
-
-JackStream::JackStream(int SampleRate) :
-    JackClient(OpenJackClient(ClientName, RealTimeThread)),
-    BufferState(),
-    RealTimeThread(JackClient, &BufferState, SampleRate)
-{ }
 
 
 JackStream::~JackStream()

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -149,6 +149,7 @@ static jack_client_t* OpenJackClient(const char*& ClientName)
 
 JackStream::JackStream(int SampleRate) :
     JackClient(OpenJackClient(ClientName)),
+    BufferState(),
     RealTimeThread(JackClient, &BufferState, SampleRate)
 {
     static_assert(std::is_same_v<jack_nframes_t, uint32_t>);

--- a/src/jack_stream.cpp
+++ b/src/jack_stream.cpp
@@ -129,7 +129,7 @@ void JackRealTimeThread::BeginFrame(FramePointers& Frame)
 // ---
 
 
-static jack_client_t* OpenJackClient(const char*& ClientName)
+static jack_client_t* OpenJackClient(const char*& ClientName, JackRealTimeThread& RealTimeThread)
 {
     jack_status_t JackStatus;
     jack_options_t JackOptions = JackNoStartServer;
@@ -143,18 +143,18 @@ static jack_client_t* OpenJackClient(const char*& ClientName)
         ClientName = jack_get_client_name(JackClient);
     }
 
+    static_assert(std::is_same_v<jack_nframes_t, uint32_t>);
+    jack_set_process_callback(JackClient, JackRealTimeThread::OnProcess, &RealTimeThread);
+
     return JackClient;
 }
 
 
 JackStream::JackStream(int SampleRate) :
-    JackClient(OpenJackClient(ClientName)),
+    JackClient(OpenJackClient(ClientName, RealTimeThread)),
     BufferState(),
     RealTimeThread(JackClient, &BufferState, SampleRate)
-{
-    static_assert(std::is_same_v<jack_nframes_t, uint32_t>);
-    jack_set_process_callback(JackClient, JackRealTimeThread::OnProcess, &RealTimeThread);
-}
+{ }
 
 
 JackStream::~JackStream()

--- a/src/jack_stream.h
+++ b/src/jack_stream.h
@@ -39,9 +39,7 @@ public:
     JackRealTimeThread(struct _jack_client* JackClient, JackThreadShared* JackBufferState, int SampleRate);
 
     virtual void BeginFrame(FramePointers& Frame) override;
-
-    static int OnProcess(uint32_t FrameCount, void *UserData);
-    int OnProcessInner(uint32_t FrameCount);
+    int OnProcess(size_t FrameCount);
 };
 
 

--- a/src/jack_stream.h
+++ b/src/jack_stream.h
@@ -1,0 +1,62 @@
+
+// Copyright 2025 Aeva Palecek
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "audio_backend.h"
+
+#include <map>
+#include <vector>
+
+
+struct _jack_client;
+struct _jack_port;
+
+
+struct JackThreadShared : AudioThreadShared
+{
+    std::vector<struct _jack_port*> OutputPorts;
+    std::map<TileHandle, struct _jack_port*> InputPorts;
+    std::map<TileHandle, struct _jack_port*> AuxOutPorts;
+};
+
+
+class JackRealTimeThread final : public RealTimeAudioThread
+{
+public:
+    JackRealTimeThread(struct _jack_client* JackClient, JackThreadShared* JackBufferState, int SampleRate);
+
+    virtual void BeginFrame(FramePointers& Frame) override;
+
+    static int OnProcess(uint32_t FrameCount, void *UserData);
+    int OnProcessInner(uint32_t FrameCount);
+};
+
+
+class JackStream final : public AudioStream
+{
+    const char* ClientName = "mollytime";
+
+    struct _jack_client* JackClient;
+    JackRealTimeThread RealTimeThread;
+    JackThreadShared BufferState;
+
+public:
+    JackStream(int SampleRate);
+    virtual ~JackStream() override;
+    
+    virtual float GetTemporalPressure() override;
+    virtual void ProgramChange(ScratchSharedPtr& NewProgram) override;
+};

--- a/src/jack_stream.h
+++ b/src/jack_stream.h
@@ -36,7 +36,7 @@ struct JackThreadShared : AudioThreadShared
 class JackRealTimeThread final : public RealTimeAudioThread
 {
 public:
-    JackRealTimeThread(struct _jack_client* JackClient, JackThreadShared* JackBufferState, int SampleRate);
+    JackRealTimeThread(JackThreadShared* JackBufferState, int SampleRate);
 
     virtual void BeginFrame(FramePointers& Frame) override;
     int OnProcess(size_t FrameCount);

--- a/src/jack_stream.h
+++ b/src/jack_stream.h
@@ -50,8 +50,8 @@ class JackStream final : public AudioStream
     const char* ClientName = "mollytime";
 
     struct _jack_client* JackClient;
-    JackRealTimeThread RealTimeThread;
     JackThreadShared BufferState;
+    JackRealTimeThread RealTimeThread;
 
 public:
     JackStream(int SampleRate);

--- a/src/jack_stream.h
+++ b/src/jack_stream.h
@@ -21,8 +21,8 @@
 #include <vector>
 
 
-struct _jack_client;
-struct _jack_port;
+struct _jack_port;      // Forward declares `typedef struct _jack_port jack_port_t` from <jack/types.h>
+struct _jack_client;    // Forward declares `typedef struct _jack_client jack_client_t` from <jack/types.h>
 
 
 struct JackThreadShared : AudioThreadShared

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -11,23 +11,41 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
-
-#pragma once
+// limitations under the License.#include "midi.h"
 
 #include "midi.h"
+#include "alsa_midi.h"
 
-struct snd_seq_t;
+#include <memory>
+#include <print>
 
-class AlsaMidiDriver final : public MidiDriver
+
+static std::unique_ptr<MidiDriver> Driver;
+
+
+void Midi::ProcessEvents(MidiHandler* Handler)
 {
-    snd_seq_t *SeqHandle = nullptr;
-    int MidiInPort = -1;
-    int MidiOutPort = -1;
+    if (Driver)
+    {
+        Driver->ProcessEvents(Handler);
+    }
+}
 
-public:
-    AlsaMidiDriver();
-    virtual ~AlsaMidiDriver() override;
 
-    void ProcessEvents(MidiHandler* Handler) override;
-};
+void Midi::Init()
+{
+#ifdef MIDI_ALSA
+    Driver = std::make_unique<AlsaMidiDriver>();
+#else
+    std::println("No MIDI driver is available.");
+#endif
+}
+
+
+void Midi::Shutdown()
+{
+    if (Driver)
+    {
+        Driver.reset();
+    }
+}

--- a/src/midi.h
+++ b/src/midi.h
@@ -15,19 +15,34 @@
 
 #pragma once
 
-#include "midi.h"
+#include <cstdint>
+#include <vector>
 
-struct snd_seq_t;
-
-class AlsaMidiDriver final : public MidiDriver
+struct MidiHandler
 {
-    snd_seq_t *SeqHandle = nullptr;
-    int MidiInPort = -1;
-    int MidiOutPort = -1;
-
-public:
-    AlsaMidiDriver();
-    virtual ~AlsaMidiDriver() override;
-
-    void ProcessEvents(MidiHandler* Handler) override;
+    virtual void NoteOn(uint8_t Note, uint8_t Velocity, uint8_t Channel)
+    {
+    }
+    virtual void NoteOff(uint8_t Note, uint8_t Channel)
+    {
+        NoteOn(Note, 0, Channel);
+    }
+    virtual void NotePressure(uint8_t Note, uint8_t Pressure, uint8_t Channel)
+    {
+    }
 };
+
+
+struct MidiDriver
+{
+    virtual ~MidiDriver() {}
+    virtual void ProcessEvents(MidiHandler* Handler) = 0;
+};
+
+
+namespace Midi
+{
+    void ProcessEvents(MidiHandler* Handler);
+    void Init();
+    void Shutdown();
+}

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -948,7 +948,7 @@ struct BlankTape : public MagicTape
             }
             Alpha = std::min(std::max(Alpha, 0.0), 1.0);
             size_t Index = size_t(double(Samples.size() - 1) * Alpha);
-            return std::min(std::max(Index, 0ul), Samples.size());
+            return std::min(std::max(Index, 0zu), Samples.size());
         }
         else
         {
@@ -956,7 +956,7 @@ struct BlankTape : public MagicTape
         }
     }
 
-    virtual double ReadAndAdvance(size_t& Index) override
+    virtual double ReadAndAdvance(uint64_t& Index) override
     {
         if (Samples.size())
         {
@@ -969,7 +969,7 @@ struct BlankTape : public MagicTape
         }
     }
 
-    virtual void WriteAndAdvance(size_t& Index, double NewSample) override
+    virtual void WriteAndAdvance(uint64_t& Index, double NewSample) override
     {
         if (Samples.size() > 0)
         {
@@ -1010,8 +1010,8 @@ struct TapeLoopThunk : public InstructionThunk
 
         double Offset = Combine(CombinerAdd, InOffset, 0.0);
         double Seconds = Combine(CombinerAdd, InLength, 0.0);
-        size_t ReadIndex = std::bit_cast<size_t, double>(ReadHead->Get());
-        size_t WriteIndex = std::bit_cast<size_t, double>(WriteHead->Get());
+        uint64_t ReadIndex = std::bit_cast<uint64_t, double>(ReadHead->Get());
+        uint64_t WriteIndex = std::bit_cast<uint64_t, double>(WriteHead->Get());
 
         auto ResetOffset = [&]()
         {
@@ -1050,11 +1050,11 @@ struct TapeLoopThunk : public InstructionThunk
             LastReset->Set(Reset);
 
             Output->Set(Tape->ReadAndAdvance(ReadIndex));
-            ReadHead->Set(std::bit_cast<double, size_t>(ReadIndex));
+            ReadHead->Set(std::bit_cast<double, uint64_t>(ReadIndex));
 
             double Sample = Combine(CombinerAdd, InSample, 0.0);
             Tape->WriteAndAdvance(WriteIndex, Sample);
-            WriteHead->Set(std::bit_cast<double, size_t>(WriteIndex));
+            WriteHead->Set(std::bit_cast<double, uint64_t>(WriteIndex));
         }
     }
 

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -1853,7 +1853,7 @@ void Patch::Recompile()
 {
     TRACEABLE_SCOPE;
     ScratchSharedPtr CurrentProgram = Compile();
-    AudioStream::Get()->ProgramChange(CurrentProgram);
+    Audio::GetStream()->ProgramChange(CurrentProgram);
 }
 
 

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -255,7 +255,7 @@ int GetClosureCount(OpCode Symbol)
 double Combine(auto& Combiner, std::vector<RunningStateSharedPtr>& Inputs, double Default=0.0)
 {
     double Result = Inputs.size() == 0 ? Default : Inputs[0]->Get();
-    for (int Index = 1; Index < Inputs.size(); ++Index)
+    for (int Index = 1; Index < static_cast<int>(Inputs.size()); ++Index)
     {
         Result = Combiner(Result, Inputs[Index]->Get());
     }
@@ -1305,7 +1305,7 @@ std::vector<PortHandle> Patch::GetTileOutputPorts(TileHandle Tile)
     int Count = SymbolInfoMap.OutputNames[(int)Symbol].size();
     std::vector<PortHandle> Handles;
     Handles.reserve(Count);
-    for (uint32_t PortIndex = 0; PortIndex < Count; ++PortIndex)
+    for (uint32_t PortIndex = 0; PortIndex < static_cast<uint32_t>(Count); ++PortIndex)
     {
         Handles.push_back(MakePortHandle(Tile, PortIndex));
     }

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -45,47 +45,46 @@ double Roll()
 }
 
 
-constexpr double MidiNoteToHz(double Note)
+// NOTE: std::pow not constexpr until C++26, and Clang 2c doesn't have it yet
+/* constexpr */ double MidiNoteToHz(double Note)
 {
-    // NOTE: std::pow not constexpr until C++26, and Clang 2c doesn't have it yet
     double Hz = std::pow(2.0, ((Note - 69.0) / 12.0)) * 440.0;
     return Hz;
 }
 
 
-constexpr double HzToMidiNote(double Hz)
+// NOTE: std::log2 not constexpr until C++26, and Clang 2c doesn't have it yet
+/* constexpr */ double HzToMidiNote(double Hz)
 {
     if (Hz <= 0.0)
     {
         return 0.0;
     }
-    // NOTE: std::log2 not constexpr until C++26, and Clang 2c doesn't have it yet
     double Note = std::log2(Hz / 440.0) * 12.0 + 69.0;
     return Note;
 }
 
 
-constexpr double AmplitudeToDecibels(double Amplitude)
+// NOTE: std::log10 not constexpr until C++26, and Clang 2c doesn't have it yet
+/* constexpr */ double AmplitudeToDecibels(double Amplitude)
 {
     // https://stackoverflow.com/questions/2445756/how-can-i-calculate-audio-db-level/9812267#9812267
-    // NOTE: std::log10 not constexpr until C++26, and Clang 2c doesn't have it yet
     double dB = 20.0 * std::log10(Amplitude);
     return dB;
 }
 
 
-constexpr double DecibelsToAmplitude(double dB)
+// NOTE: std::pow not constexpr until C++26, and Clang 2c doesn't have it yet
+/* constexpr */ double DecibelsToAmplitude(double dB)
 {
-    // NOTE: std::pow not constexpr until C++26, and Clang 2c doesn't have it yet
     double Amplitude = std::pow(10.0, dB / 20.0);
     return Amplitude;
 }
 
 
-constexpr double PerceptualAmplitudeCorrectionByMidiNoteInner(double Note)
+// NOTE: Not constexpr until required C++26 features land.  See above notes
+/* constexpr */ double PerceptualAmplitudeCorrectionByMidiNoteInner(double Note)
 {
-    // NOTE: Not constexpr until required C++26 features land.  See above notes
-
     // https://merveilles.town/@cancel/114848900879804284
     const double Peak = AmplitudeToDecibels(1.0);
     const double LowEdge = HzToMidiNote(2000.0) - 6.0;
@@ -104,8 +103,8 @@ constexpr double PerceptualAmplitudeCorrectionByMidiNoteInner(double Note)
     return DecibelsToAmplitude(dB);
 }
 
-
-constexpr double PerceptualAmplitudeCorrectionByMidiNote(double Note)
+// NOTE: Not constexpr until required C++26 features land.  See above notes
+/* constexpr */ double PerceptualAmplitudeCorrectionByMidiNote(double Note)
 {
     // TODO: Make this constexpr once the required C++26 features land
     static const double Scale = 1.0 / PerceptualAmplitudeCorrectionByMidiNoteInner(HzToMidiNote(50.0));
@@ -113,8 +112,8 @@ constexpr double PerceptualAmplitudeCorrectionByMidiNote(double Note)
     return PerceptualAmplitudeCorrectionByMidiNoteInner(Note) * Scale;
 }
 
-
-constexpr double PerceptualAmplitudeCorrectionByHz(double Hz)
+// NOTE: Not constexpr until required C++26 features land.  See above notes
+/* constexpr */ double PerceptualAmplitudeCorrectionByHz(double Hz)
 {
     if (Hz <= 0.0)
     {

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -1287,10 +1287,10 @@ std::vector<PortHandle> Patch::GetTileInputPorts(TileHandle Tile)
 {
     TRACEABLE_SCOPE;
     OpCode Symbol = GetTileSymbol(Tile);
-    int Count = SymbolInfoMap.InputNames[(int)Symbol].size();
+    size_t Count = SymbolInfoMap.InputNames[(int)Symbol].size();
     std::vector<PortHandle> Handles;
     Handles.reserve(Count);
-    for (int PortIndex = 0; PortIndex < Count; ++PortIndex)
+    for (int PortIndex = 0; PortIndex < static_cast<int>(Count); ++PortIndex)
     {
         Handles.push_back(MakePortHandle(Tile, PortIndex));
     }
@@ -1302,7 +1302,7 @@ std::vector<PortHandle> Patch::GetTileOutputPorts(TileHandle Tile)
 {
     TRACEABLE_SCOPE;
     OpCode Symbol = GetTileSymbol(Tile);
-    int Count = SymbolInfoMap.OutputNames[(int)Symbol].size();
+    size_t Count = SymbolInfoMap.OutputNames[(int)Symbol].size();
     std::vector<PortHandle> Handles;
     Handles.reserve(Count);
     for (uint32_t PortIndex = 0; PortIndex < static_cast<uint32_t>(Count); ++PortIndex)
@@ -1485,11 +1485,11 @@ ScratchSharedPtr Patch::Compile()
             return nullptr;
         }
 
-        const int InputCount = SymbolInfoMap.InputNames[(int)Symbol].size();
-        const int OutputCount = SymbolInfoMap.OutputNames[(int)Symbol].size();
+        const size_t InputCount = SymbolInfoMap.InputNames[(int)Symbol].size();
+        const size_t OutputCount = SymbolInfoMap.OutputNames[(int)Symbol].size();
 
         // Recurse first to populate everything sequentally.
-        for (int PortIndex = 0; PortIndex < InputCount; ++PortIndex)
+        for (int PortIndex = 0; PortIndex < static_cast<int>(InputCount); ++PortIndex)
         {
             PortHandle InputHandle = MakePortHandle(Tile, PortIndex);
             for (PortHandle ConnectedOutput : ByInput.at(InputHandle))
@@ -1532,7 +1532,7 @@ ScratchSharedPtr Patch::Compile()
         else
         {
             std::vector<std::vector<RunningStateSharedPtr>> Inputs;
-            for (int PortIndex = 0; PortIndex < InputCount; ++PortIndex)
+            for (int PortIndex = 0; PortIndex < static_cast<int>(InputCount); ++PortIndex)
             {
                 std::vector<RunningStateSharedPtr>& PortInputs = Inputs.emplace_back();
                 PortHandle InputHandle = MakePortHandle(Tile, PortIndex);
@@ -1543,7 +1543,7 @@ ScratchSharedPtr Patch::Compile()
             }
 
             std::vector<RunningStateSharedPtr> Outputs;
-            for (int PortIndex = 0; PortIndex < OutputCount; ++PortIndex)
+            for (int PortIndex = 0; PortIndex < static_cast<int>(OutputCount); ++PortIndex)
             {
                 PortHandle OutputHandle = MakePortHandle(Tile, PortIndex);
                 Outputs.push_back(ActiveOutputs.at(OutputHandle));

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -19,6 +19,7 @@
 #include <print>
 #include <functional>
 #include <limits>
+#include <numbers>
 #include <utility>
 #include <cmath>
 #include <bit>
@@ -27,9 +28,8 @@
 #include "patch.h"
 #include "audio_backend.h"
 
-
-constinit double Pi = M_PI;
-constinit double Tau = M_PI * 2.0;
+constinit double Pi = std::numbers::pi;
+constinit double Tau = std::numbers::pi * 2.0;
 
 const double ImprobableMagnitude = 123456789.0;
 

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -28,8 +28,8 @@
 #include "patch.h"
 #include "audio_backend.h"
 
-constinit double Pi = std::numbers::pi;
-constinit double Tau = std::numbers::pi * 2.0;
+constexpr double Pi = std::numbers::pi;
+constexpr double Tau = std::numbers::pi * 2.0;
 
 const double ImprobableMagnitude = 123456789.0;
 
@@ -107,7 +107,7 @@ constexpr double PerceptualAmplitudeCorrectionByMidiNoteInner(double Note)
 
 constexpr double PerceptualAmplitudeCorrectionByMidiNote(double Note)
 {
-    // TODO: Make this constinit once the required C++26 features land
+    // TODO: Make this constexpr once the required C++26 features land
     static const double Scale = 1.0 / PerceptualAmplitudeCorrectionByMidiNoteInner(HzToMidiNote(50.0));
 
     return PerceptualAmplitudeCorrectionByMidiNoteInner(Note) * Scale;

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -1512,10 +1512,7 @@ ScratchSharedPtr Patch::Compile()
             }
             else if (ConnectedOutputs.size() == 1)
             {
-                for (PortHandle ConnectedOutput : ConnectedOutputs)
-                {
-                    return ActiveOutputs.at(ConnectedOutput);
-                }
+                return ActiveOutputs.at(*ConnectedOutputs.begin());
             }
             else
             {
@@ -1800,8 +1797,6 @@ ScratchSharedPtr Patch::Compile()
             }
             return nullptr;
         }
-
-        std::unreachable();
     };
 
     std::vector<TileHandle> Scopes;

--- a/src/patch.h
+++ b/src/patch.h
@@ -221,7 +221,7 @@ struct InstructionThunk
 };
 
 
-struct Scratch : public MidiHandler
+struct Scratch final : public MidiHandler
 {
     std::vector<std::shared_ptr<InstructionThunk>> Program;
     std::vector<RunningStateSharedPtr> Outputs;

--- a/src/patch.h
+++ b/src/patch.h
@@ -155,12 +155,12 @@ struct MagicTape
         return 0;
     }
 
-    virtual double ReadAndAdvance(size_t& Index)
+    virtual double ReadAndAdvance(uint64_t& Index)
     {
         return 0.0;
     }
 
-    virtual void WriteAndAdvance(size_t& Index, double NewSample)
+    virtual void WriteAndAdvance(uint64_t& Index, double NewSample)
     {
     }
 

--- a/src/perf.h
+++ b/src/perf.h
@@ -17,7 +17,10 @@
 #define FORCE_SAMPLE_PROFILING 0
 
 #if defined(TRACY_ENABLE) && !FORCE_SAMPLE_PROFILING
+#pragma warning(push)
+#pragma warning(disable : 4464)
 #include "tracy/Tracy.hpp"
+#pragma warning(pop)
 
 #define DECLARE_TRACEABLE_MUTEX(NAME) TracyLockable(std::mutex, NAME)
 #define TRACEABLE_LOCK_GUARD(LOCK_VAR) std::lock_guard<LockableBase(std::mutex)> LOCK_GUARD_##__LINE__(LOCK_VAR)

--- a/src/py_api.cpp
+++ b/src/py_api.cpp
@@ -211,9 +211,9 @@ PYBIND11_MODULE(mollytime, m) {
 		.def("read_scope_probe", &Patch::ReadScopeProbe)
 		.def("set_special_input", &Patch::SetSpecialInput);
 
-	m.def("init_audio", &AudioStream::Init);
-	m.def("shutdown_audio", &AudioStream::Shutdown);
-	m.def("get_temporal_pressure", &AudioStream::GetTemporalPressure);
+	m.def("init_audio", &Audio::Init);
+	m.def("shutdown_audio", &Audio::Shutdown);
+	m.def("get_temporal_pressure", &Audio::GetTemporalPressure);
 
 	m.def("init_midi", &Midi::Init);
 	m.def("shutdown_midi", &Midi::Shutdown);

--- a/src/py_api.cpp
+++ b/src/py_api.cpp
@@ -16,8 +16,18 @@
 #include <cstdint>
 #include <stdexcept>
 #include <algorithm>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#pragma warning(push)
+#pragma warning(disable : 4191 4355 4371 4464 4686 4868 5039)
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#pragma warning(pop)
+#pragma clang diagnostic pop
+
 #include "colors.h"
 #include "patch.h"
 #include "audio_backend.h"


### PR DESCRIPTION
This allows the project to cleanly build on Windows, with strict warnings, via both Clang and MSVC, although no Windows build machinery is provided as of yet.

Three categories of changes, broadly:

1. Address MSVC-specific portability issues. There weren't many of these -- lack of `M_PI`, and MSVC's strictness about `size_t` and `constexpr`-ness, were the only major offenders.

2. Flip on extended Clang & MSVC warnings, and fix anything that emerges. This mostly concerned possibly-unsafe integer conversions. They're still unsafe -- we'd need something like `gsl::narrow()` if we wanted to actually assert that all conversions are valid -- but they now clearly signal intent, satisfying both compilers. We also need to ignore warnings emitted by third-party headers; this currently just uses pragmas for both compilers, which doesn't not compile, but ideally these could become conditionally-definable pragma strings, possibly constrained to a wrapper header.

3. Isolate the Alsa-MIDI and JACK backends behind an abstract interface. This doesn't change the static interface used by Python; it's just an implementation refactor. Other than ensuring all third-party dependencies are isolated to a single conditionally-compiled translation unit (per backend), this mainly involved construct/destruct cleanup, to ensure that all backend state is properly encapsulated, and tied to the backend's lifetime. By my measure, this has actually led to ~100 *fewer* lines of implementation code at the end of the day.