### PR TITLE
Add Meson build, supporting both Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,55 @@ and installation art.
 While Mollytime is already quite usable, it is still missing quite a bit of
 polish and several major features, and is not quite ready for prime time.
 
+In particular, even though a Windows build is currently provided, it doesn't
+yet have any audio backends implemented, so you won't be able to hear anything.
+
 # I want to use it anyway!
 
-Right now Mollytime only has a build system for Linux.  To try it out anyway
-you will need the following software installed on your Linux computer:
+Mollytime currently uses the [Meson](https://mesonbuild.com/) build system.
 
- - Python
- - Pygame
- - Clang
- - Pybind11
- - Jack
- 
+Supported platforms, as in "we've tried these and it seems to work fine":
+- Linux, via Clang or GCC, using glibc
+- Windows, via Clang or MSVC, using MSVC 2022
+
+Mollytime is a Python-based project, so you'll naturally need Python 3. Otherwise,
+most dependencies can be acquired via `pip`. (Setting up a virtual environment
+first is supported and recommended.)
+- `pip install meson`
+- `pip install ninja` (if using Meson's default Ninja backend)
+- `pip install pygame`
+- `pip install pybind11`
+
+Other dependencies you'll currently need to acquire yourself:
+- JACK, if building with the JACK audio backend.
+- `boost_stacktrace`, if building with stacktrace support.
+
 Once you have determined the correct versions of each of these dependencies,
-please let me know and I'll write them down here.  Then run the following
-command to build the game:
+please let me know and I'll write them down here.
 
- - `make`
- 
+Then, look at `meson.options` to see available build options. You'll probably
+want to select an `audio_backend`, at minimum. Be sure to reference Meson's
+[built-in options](https://mesonbuild.com/Builtin-options.html) for anything
+not covered here, like whether or not to emit optimized builds.
+
+> IMPORTANT: On Linux, you'll currently need to disable Meson's `b_asneeded` and
+`b_lundef` options, until we add a way to handle this kind of configuration for you.
+
+An example command sequence for building an optimized "release" build for Linux,
+using Clang:
+```
+CXX=clang++ meson setup -Dbuildtype=release -Db_asneeded=false -Db_lundef=false -Daudio_backend=jack -Dmidi_backend=alsa build
+meson compile -C build
+meson install -C build
+```
+
+An example command sequence for building a "debug" build on Windows, using MSVC:
+```
+meson setup -Dbuildtype=debug -Daudio_backend=wasapi build
+meson compile -C build
+meson install -C build
+```
+
 If all goes well, you will then be able to run Mollytime like so:
 
  - `python mollytime`
-
-# I want to use it anyway, and I use Windows, the other operating system!
-
-A Windows port is planned, please be patient.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ yet have any audio backends implemented, so you won't be able to hear anything.
 
 # I want to use it anyway!
 
-Mollytime currently uses the [Meson](https://mesonbuild.com/) build system.
+Mollytime uses the [Meson](https://mesonbuild.com/) build system.
 
 Supported platforms, as in "we've tried these and it seems to work fine":
 - Linux, via Clang or GCC, using glibc

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,12 @@ library_dirs = []
 dependencies = []
 source_files = []
 
+# We'll need to link `dl` (dynamic linking) and `m` (math) on non-Windows.
+if build_machine.system() != 'windows'
+    dependencies += compiler.find_library('m')
+    dependencies += compiler.find_library('dl')
+endif
+
 # ---
 # Warning wrangling 🤠
 
@@ -81,7 +87,15 @@ foreach include : pybind_include_string.split(' ')
     message(f'Pybind11 include directory: "@include@"')
 endforeach
 
-pybind_suffix_command = run_command(python, '-m', 'pybind11', '--extension-suffix', check : true)
+# Windows doesn't (easily) provide `python3-config`, so pybind11 produces an equivalent for getting the `--extension-suffix`.
+# ...On Windows only. It omits this elsewhere, so we've got to change which one we're invoking depending on platform.
+if build_machine.system() == 'windows'
+    python_suffix_command_args = [ python, '-m', 'pybind11', '--extension-suffix' ]
+else
+    python_suffix_command_args = [ 'python3-config', '--extension-suffix' ]
+endif
+
+pybind_suffix_command = run_command(python_suffix_command_args, check : true)
 pybind_suffix = pybind_suffix_command.stdout().strip()
 
 # `pybind11 --extension-suffix` includes the leading `.`, but Meson wants to add this itself.
@@ -104,7 +118,7 @@ endif
 # MIDI backend
 
 if get_option('midi_backend') == 'alsa'
-    dependencies += dependency('asound', required : true)
+    dependencies += compiler.find_library('asound', required : true)
     add_project_arguments('-DMIDI_ALSA=1', language: 'cpp')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,172 @@
+project('mollytime', 'cpp',
+    meson_version : '>=1.3.0',
+    default_options : [
+        'cpp_std=c++23,c++latest',
+        'warning_level=3'   # GCC-style: `-Wall -Wextra -pedantic`; MSVC-style: `/W4`
+    ]
+)
+
+fs = import('fs')
+py = import('python')
+
+compiler = meson.get_compiler('cpp')
+project_dir = meson.project_source_root()
+
+include_dirs = []
+library_dirs = []
+dependencies = []
+source_files = []
+
+# ---
+# Warning wrangling 🤠
+
+if compiler.get_argument_syntax() == 'gcc'
+    add_project_arguments(
+        '-Wshadow',
+        '-Wno-unused-parameter',
+        '-Wno-unknown-pragmas',
+        language: 'cpp'
+    )
+elif compiler.get_argument_syntax() == 'msvc'
+    add_project_arguments(
+        '/wd4068',  # Disable 'Unused parameter'
+        '/wd4100',  # Disable 'Unknown pragma'
+        language: 'cpp'
+    )
+endif
+
+# ---
+# Python
+
+python_install = py.find_installation()
+python = python_install.full_path()
+
+# On Windows, we need an explicit path to the Python static library directory, for pybind11.
+if build_machine.system() == 'windows'
+    base_prefix_command = run_command(python, '-c', 'import sys; print(sys.base_prefix)', check : true)
+    base_prefix = base_prefix_command.stdout().strip()
+    python_libs_path = base_prefix / 'libs'
+    library_dirs += f'-L@python_libs_path@'
+    message(f'Python `libs` directory: "@python_libs_path@"')
+endif
+
+# ---
+# GLM
+
+glm_include = 'third_party' / 'glm-0.9.9.8'
+include_dirs += include_directories(glm_include)
+
+# ---
+# Pybind11
+
+pybind_includes_command = run_command(python, '-m', 'pybind11', '--includes', check : true)
+pybind_include_string = pybind_includes_command.stdout().strip()
+
+# `pybind11 --includes` returns whitespace-separated, GCC-style `-I` syntax.
+# We need to extract each path as a separate item, with no prefix.
+foreach include : pybind_include_string.split(' ')
+    include = include.strip()
+
+    # Remove -I prefix.
+    if include.startswith('-I')
+        include = include.substring(2)
+    endif
+
+    # Meson doesn't accept absolute paths that point inside the project directory.
+    # Make any such paths relative before including.
+    if include.startswith(project_dir)
+        include = fs.relative_to(include, project_dir)
+    endif
+    include_dirs += include_directories(include)
+    message(f'Pybind11 include directory: "@include@"')
+endforeach
+
+pybind_suffix_command = run_command(python, '-m', 'pybind11', '--extension-suffix', check : true)
+pybind_suffix = pybind_suffix_command.stdout().strip()
+
+# `pybind11 --extension-suffix` includes the leading `.`, but Meson wants to add this itself.
+if pybind_suffix.startswith('.')
+    pybind_suffix = pybind_suffix.substring(1)
+endif
+
+# ---
+# Audio backend
+
+if get_option('audio_backend') == 'jack'
+    dependencies += dependency('jack', required : true)
+    add_project_arguments('-DENABLE_JACK=1', language : 'cpp')
+elif get_option('audio_backend') == 'wasapi'
+    dependencies += compiler.find_library('RuntimeObject', required : true)
+    add_project_arguments('-DAUDIO_WASAPI=1', language : 'cpp')
+endif
+
+# ---
+# MIDI backend
+
+if get_option('midi_backend') == 'alsa'
+    dependencies += dependency('asound', required : true)
+    add_project_arguments('-DMIDI_ALSA=1', language: 'cpp')
+endif
+
+# ---
+# Stack trace
+
+# Ideally, we can grab Boost as a system-known dependency. (Meson has internal magic for this.)
+# If not -- i.e, on Windows -- we'll look for a fallback in the `third_party` directory.
+
+
+if get_option('boost_stacktrace').enabled()
+    boost_stacktrace = dependency('boost', required : false)
+    if boost_stacktrace.found()
+        dependencies += boost_stacktrace
+    elif get_option('boost_stacktrace').enabled()
+        boost_stacktrace_dir = 'third_party' / 'boost-stacktrace-1.89.0'
+        include_dirs += include_directories(boost_stacktrace_dir / 'include')
+        message(f'boost_stacktrace: Fallback found: "@boost_stacktrace_dir@"')
+    endif
+
+    add_project_arguments('-DENABLE_STACK_TRACES=1', language : 'cpp')
+    if build_machine.system() == 'windows'
+        add_project_arguments('-DBOOST_STACKTRACE_USE_WINDBG=1', language: 'cpp')
+    endif
+endif
+
+# ---
+# Tracy
+
+if get_option('tracy').enabled()
+    tracy_dir = 'third_party' / 'tracy-0.12.2' / 'public'
+    add_project_arguments('-DTRACY_ENABLE', language: 'cpp')
+    include_dirs += include_directories(tracy_dir)
+    source_files += tracy_dir / 'TracyClient.cpp'
+
+    if build_machine.system() != 'windows'
+        dependencies += dependency('threads')
+    endif
+endif
+
+# ---
+# mollytime library
+
+source_files += [
+    'src/alsa_midi.cpp',
+    'src/audio_backend.cpp',
+    'src/colors.cpp',
+    'src/errors.cpp',
+    'src/jack_stream.cpp',
+    'src/midi.cpp',
+    'src/patch.cpp',
+    'src/perf.cpp',
+    'src/py_api.cpp'
+]
+
+shared_library(
+    'mollytime',
+    source_files,
+    name_suffix : pybind_suffix,
+    include_directories : include_dirs,
+    link_args : library_dirs,
+    dependencies : dependencies,
+    install : true,
+    install_dir : project_dir / 'mollytime'
+)

--- a/meson.build
+++ b/meson.build
@@ -128,7 +128,6 @@ endif
 # Ideally, we can grab Boost as a system-known dependency. (Meson has internal magic for this.)
 # If not -- i.e, on Windows -- we'll look for a fallback in the `third_party` directory.
 
-
 if get_option('boost_stacktrace').enabled()
     boost_stacktrace = dependency('boost', required : false)
     if boost_stacktrace.found()
@@ -177,6 +176,7 @@ source_files += [
 shared_library(
     'mollytime',
     source_files,
+    name_prefix : [],
     name_suffix : pybind_suffix,
     include_directories : include_dirs,
     link_args : library_dirs,

--- a/meson.build
+++ b/meson.build
@@ -176,7 +176,7 @@ source_files += [
 shared_library(
     'mollytime',
     source_files,
-    name_prefix : [],
+    name_prefix : '',
     name_suffix : pybind_suffix,
     include_directories : include_dirs,
     link_args : library_dirs,

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,4 @@
+option('audio_backend', type : 'combo', choices: ['none', 'jack', 'wasapi'])
+option('midi_backend', type : 'combo', choices: ['none', 'alsa'])
+option('boost_stacktrace', type : 'feature', value : 'auto')
+option('tracy', type : 'feature', value: 'disabled')


### PR DESCRIPTION
Here it is!

Users can get Meson (and Ninja, if using the default backend) however they want, but I just ran `pip install meson ninja` in the virtual environment I've set up, which works great.

Once that's acquired, build the project on either platform by going:
- `meson setup <options> build`
- `meson compile -C build`
- `meson install -C build`

There's nothing too esoteric happening here that isn't communicated by `meson.build`. Most esoterica is contained in that `<options>` qualifier:
- This is where you put any [built-in Meson options](https://mesonbuild.com/Builtin-options.html), like `-Dbuildtype=release`.
- On Linux, it is **required** to pass `-Db_asneeded=false` and `-Db_lundef=false`, or Pybind11 will fail to link.
- The project also defines a few of its own options; see `meson.options`. In particular, no audio or MIDI backend is selected by default, so you'll need to pick one to get any real functionality, e.g. `-Daudio_backend=jack`.

By default, the build will use the first compiler it finds on the system, typically GCC on Linux or MSVC on Windows. To pass in your own toolchain, set some environment variables first:
- On Linux and Windows, `CXX=<path to my C++ compiler>`.
- On Windows, if using Clang, `CXX_LD=lld` and `AR=<path to LLVM binaries>/llvm-ar`.

Most of this configuration grit can, and should, be moved into configuration files that we can add to the repository, which I'll look into later.

I'm sure the build file is now perfect, and we'll never need to edit it or account for any platform quirks ever again, but it's intended to be easily readable & maintainable, so please point out anything that seems weird and/or bad.