### PR TITLE
Add WASAPI backend (output only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ first is supported and recommended.)
 
 Other dependencies you'll currently need to acquire yourself:
 - JACK, if building with the JACK audio backend.
+- Windows 11 SDK (10.0.22621.5040) or newer, if building with the WASAPI backend. (Don't worry, it also works with Windows 10.)
 - `boost_stacktrace`, if building with stacktrace support.
 
 Once you have determined the correct versions of each of these dependencies,

--- a/meson.build
+++ b/meson.build
@@ -170,7 +170,8 @@ source_files += [
     'src/midi.cpp',
     'src/patch.cpp',
     'src/perf.cpp',
-    'src/py_api.cpp'
+    'src/py_api.cpp',
+    'src/wasapi_stream.cpp'
 ]
 
 shared_library(

--- a/src/audio_backend.cpp
+++ b/src/audio_backend.cpp
@@ -14,7 +14,12 @@
 // limitations under the License.
 
 #include "audio_backend.h"
+
+#ifdef ENABLE_JACK
 #include "jack_stream.h"
+#elifdef AUDIO_WASAPI
+#include "wasapi_stream.h"
+#endif
 
 #include <memory>
 #include <print>
@@ -143,6 +148,8 @@ void Audio::Init(int SampleRate)
 {
 #ifdef ENABLE_JACK
     Stream = std::make_unique<JackStream>(SampleRate);
+#elifdef AUDIO_WASAPI
+    Stream = std::make_unique<WasapiStream>(SampleRate);
 #else
     std::println("No audio stream implementation is available.");
     Stream = std::make_unique<StubStream>();

--- a/src/wasapi_stream.cpp
+++ b/src/wasapi_stream.cpp
@@ -1,0 +1,192 @@
+
+// Copyright 2025 Aeva Palecek
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef AUDIO_WASAPI
+
+#include "wasapi_stream.h"
+
+#include <cassert>
+#include <span>
+
+
+#define CheckHResult winrt::check_hresult
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
+const IID IID_IAudioClient = __uuidof(IAudioClient);
+#pragma clang diagnostic pop
+
+
+WasapiRealTimeThread::WasapiRealTimeThread(WasapiThreadShared* WasapiBufferState, int SampleRate)
+{
+    assert(WasapiBufferState != nullptr);
+    assert(SampleRate != 0);
+
+    BufferState = WasapiBufferState;
+    SampleInterval = 1.0 / double(SampleRate);
+    ResetFramePressure();
+
+    // Entering the "COM zone."
+    CheckHResult(CoInitializeEx(nullptr, COINIT_MULTITHREADED));
+
+    // Get the default audio device (hardware endpoint).
+    ComPtr<IMMDeviceEnumerator> Enumerator;
+    Enumerator.capture(CoCreateInstance, CLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL);
+
+    CheckHResult(Enumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, Device.put()));
+
+    // Activate and initialize an audio client (stream to hardware endpoint).
+    CheckHResult(Device->Activate(IID_IAudioClient, CLSCTX_ALL, nullptr, AudioClient.put_void()));
+
+    REFERENCE_TIME DevicePeriod;
+    CheckHResult(AudioClient->GetDevicePeriod(nullptr, &DevicePeriod));
+
+    WAVEFORMATEX *WaveFormat;
+    CheckHResult(AudioClient->GetMixFormat(&WaveFormat));
+    assert(WaveFormat != nullptr);
+
+    CheckHResult(AudioClient->Initialize(
+        AUDCLNT_SHAREMODE_SHARED,           // Non-exclusive audio output.
+        AUDCLNT_STREAMFLAGS_EVENTCALLBACK,  // Use a waitable Event to signal when more audio is needed.
+        DevicePeriod,
+        DevicePeriod,
+        WaveFormat,
+        nullptr
+    ));
+
+    CoTaskMemFree(WaveFormat);
+
+    // Fire this event when more audio is needed.
+    // Initialize it in the "signaled" state, so that our first loop iteration fills the audio buffer.
+    EventHandle = CreateEvent(nullptr, FALSE, TRUE, nullptr);
+    CheckHResult(AudioClient->SetEventHandle(EventHandle));
+
+    // Initialize intermediate stereo buffers. (We'll need to interleave samples before sending to the WASAPI output buffer.)
+    CheckHResult(AudioClient->GetBufferSize(&BufferSize));
+    WasapiBufferState->OutputSamplesLeft.resize(BufferSize);
+    WasapiBufferState->OutputSamplesRight.resize(BufferSize);
+
+    // Set up a render client (output interface to the IAudioClient stream).
+    RenderClient.capture(AudioClient, &IAudioClient::GetService);
+
+    // Ready to go! Start streaming in separate thread.
+    AudioClient->Start();
+    new(&LoopThread) std::thread(&WasapiRealTimeThread::Loop, this);
+}
+
+
+WasapiRealTimeThread::~WasapiRealTimeThread()
+{
+    // Join the audio thread, ending the stream.
+    IsRunning.store(false);
+    LoopThread.join();
+
+    // End the audio stream.
+    AudioClient->Stop();
+
+    // Exit the COM zone.
+    CoUninitialize();
+}
+
+
+void WasapiRealTimeThread::BeginFrame(FramePointers& Frame)
+{
+    assert(BufferState != nullptr);
+
+    WasapiThreadShared& WasapiBufferState = static_cast<WasapiThreadShared &>(*BufferState);
+    assert(WasapiBufferState.OutputSamplesLeft.size() >= Frame.SampleCount);
+    assert(WasapiBufferState.OutputSamplesRight.size() >= Frame.SampleCount);
+
+    Frame.OutLeft = WasapiBufferState.OutputSamplesLeft.data();
+    Frame.OutRight = WasapiBufferState.OutputSamplesRight.data();
+}
+
+
+void WasapiRealTimeThread::EndFrame(FramePointers& Frame)
+{
+    struct OutputFrame
+    {
+        float Left;
+        float Right;
+    };
+    static_assert(sizeof(OutputFrame) == sizeof(float) * 2);
+
+    TRACEABLE_SCOPE;
+
+    assert(BufferState != nullptr);
+    assert(RenderClient);
+
+    // Now that we've collected stereo samples into our intermediate buffers, get the WASAPI output buffer.
+    // Its size will be (SampleCount * sizeof(OutputFrame)).
+    BYTE *Data;
+    CheckHResult(RenderClient->GetBuffer(static_cast<UINT32>(Frame.SampleCount), &Data));
+    std::span<OutputFrame> OutputFrames(reinterpret_cast<OutputFrame *>(Data), Frame.SampleCount);
+
+    // Interleave samples.
+    WasapiThreadShared& WasapiBufferState = static_cast<WasapiThreadShared &>(*BufferState);
+    for (ptrdiff_t OutputFrameIndex = 0; OutputFrameIndex < std::ssize(OutputFrames); OutputFrameIndex++)
+    {
+        OutputFrame& OutputFrame = OutputFrames[OutputFrameIndex];
+        OutputFrame.Left = WasapiBufferState.OutputSamplesLeft[OutputFrameIndex];
+        OutputFrame.Right = WasapiBufferState.OutputSamplesRight[OutputFrameIndex];
+    }
+
+    // Release the buffer, letting WASAPI know it's safe to send it over to the hardware endpoint.
+    CheckHResult(RenderClient->ReleaseBuffer(Frame.SampleCount, 0));
+}
+
+
+void WasapiRealTimeThread::Loop()
+{
+    IsRunning.store(true);
+    while(IsRunning.load())
+    {
+        // Wait until more audio is needed.
+        WaitForSingleObject(EventHandle, 1000);
+
+        // The output buffer might not be *completely* empty.
+        // Any data not yet processed is called "padding", and should be subtracted from the write count.
+        UINT32 BufferPadding;
+        CheckHResult(AudioClient->GetCurrentPadding(&BufferPadding));
+
+        FramePointers Frame;
+        Frame.SampleCount = BufferSize - BufferPadding;
+        AdvanceFrames(Frame);
+    }
+}
+
+
+WasapiStream::WasapiStream(int SampleRate) :
+    BufferState(),
+    RealTimeThread(&BufferState, SampleRate)
+{ }
+
+
+float WasapiStream::GetTemporalPressure()
+{
+    TRACEABLE_SCOPE;
+    return BufferState.TemporalPressure.load();
+}
+
+
+void WasapiStream::ProgramChange(ScratchSharedPtr& NewProgram)
+{
+    TRACEABLE_SCOPE;
+    TRACEABLE_LOCK_GUARD(BufferState.Mutex);
+    BufferState.PendingProgram = NewProgram;
+}
+
+#endif

--- a/src/wasapi_stream.h
+++ b/src/wasapi_stream.h
@@ -1,0 +1,80 @@
+
+// Copyright 2025 Aeva Palecek
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef AUDIO_WASAPI
+
+#include "audio_backend.h"
+
+#include <thread>
+#include <vector>
+
+#define WIN32_LEAN_AND_MEAN
+#define MSVC_EXTRA_LEAN
+#define NOMINMAX
+#include <Audioclient.h>
+#include <mmdeviceapi.h>
+#include <winrt/base.h>
+#undef NOMINMAX
+#undef MSVC_EXTRA_LEAN
+#undef WIN32_LEAN_AND_MEAN
+
+
+template<typename T>
+using ComPtr = winrt::com_ptr<T>;
+
+
+struct WasapiThreadShared final : AudioThreadShared
+{
+    std::vector<float> OutputSamplesLeft;
+    std::vector<float> OutputSamplesRight;
+};
+
+
+class WasapiRealTimeThread final : public RealTimeAudioThread
+{
+    ComPtr<IMMDevice> Device;
+    ComPtr<IAudioClient> AudioClient;
+    ComPtr<IAudioRenderClient> RenderClient;
+    UINT32 BufferSize;
+    HANDLE EventHandle = nullptr;
+
+    std::thread LoopThread;
+    std::atomic<bool> IsRunning;
+    void Loop();
+
+public:
+    WasapiRealTimeThread(WasapiThreadShared* WasapiBufferState, int SampleRate);
+    virtual ~WasapiRealTimeThread() override;
+
+    virtual void BeginFrame(FramePointers& Frame) override;
+    virtual void EndFrame(FramePointers& Frame) override;
+};
+
+
+class WasapiStream final : public AudioStream
+{
+    WasapiThreadShared BufferState;
+    WasapiRealTimeThread RealTimeThread;
+
+public:
+    WasapiStream(int SampleRate);
+
+    virtual float GetTemporalPressure() override;
+    virtual void ProgramChange(ScratchSharedPtr& NewProgram) override;
+};
+
+#endif

--- a/src/wasapi_stream.h
+++ b/src/wasapi_stream.h
@@ -23,13 +23,13 @@
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
-#define MSVC_EXTRA_LEAN
+#define VC_EXTRALEAN
 #define NOMINMAX
 #include <Audioclient.h>
 #include <mmdeviceapi.h>
 #include <winrt/base.h>
 #undef NOMINMAX
-#undef MSVC_EXTRA_LEAN
+#undef VC_EXTRALEAN
 #undef WIN32_LEAN_AND_MEAN
 
 


### PR DESCRIPTION
`#define AUDIO_WASAPI` to turn it on. The Meson build will handle this for you if `audio_backend` is set to `wasapi`.

WASAPI's scope is limited to interfacing with hardware endpoints, so the "input" and "aux" capabilities of the JACK backend -- which can pipe audio to and from any number of arbitrary "software" endpoints -- aren't straightforwardly applicable. We'll have to do something else to get that functionality on Windows, if desired.

There's no inherent "server" thread with WASAPI; we're responsible for execution control. This means that the `WasapiRealTimeThread` does genuinely need to run in a separate `std::thread` loop. Likewise, all of the COM objects we're handling are logically owned by the independent RealTimeThread that needs them, rather than the backend; the latter is thus limited to nothing more than main-thread ownership of the RealTimeThread and its BufferState.

The other major discrepancy is that WASAPI expects left/right stereo samples to be interleaved into consecutive "frames," rather than written independently. To prevent any higher-level changes, the backend takes care of it -- all samples are written into per-channel intermediate buffers, and then interleaved into the WASAPI output buffer on `EndFrame()`. This costs a little bit of extra memory (~2 KB), and presumably a little extra time (not measurably significant in Tracy).

Otherwise, implementation is straightforward:
- Initialize COM, and the minimal necessary WASAPI infrastructure. This includes getting the default `IMMDevice` (hardware endpoint), activating an `IAudioClient` (generic audio stream to the endpoint), for which we set up an `IAudioRenderClient` ("render", i.e. output, interface for the audio stream).
- Audio client initialization specifies "shared" mode -- i.e., not exclusive -- and uses an Event handle to signal when the buffer needs filling, so we don't have to manually calculate the timing ourselves.
- Once everything's ready to go, just loop the thread until shutdown. On shutdown, signal to the thread (via atomic bool) that we're done, and safely join before shutting down the audio stream.

Note: I'm using the WinRT `com_ptr` -- the latest in a long line of such -- to manage COM objects and their lifetimes. This is technically available on any WASAPI-capable Windows SDK, but on older SDK versions, it'll fail to compile in C++23 mode due to outdated experimental coroutine headers. Compiling with "Windows 11 SDK (10.0.22621.5040)" or newer is recommended. (Don't worry, it works just fine on Windows 10.) I've update the readme to reflect this.