### PR TITLE
Build cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ and installation art.
 While Mollytime is already quite usable, it is still missing quite a bit of
 polish and several major features, and is not quite ready for prime time.
 
-In particular, even though a Windows build is currently provided, it doesn't
-yet have any audio backends implemented, so you won't be able to hear anything.
-
 # I want to use it anyway!
 
 Mollytime uses the [Meson](https://mesonbuild.com/) build system.
@@ -40,25 +37,12 @@ Other dependencies you'll currently need to acquire yourself:
 Once you have determined the correct versions of each of these dependencies,
 please let me know and I'll write them down here.
 
-Then, look at `meson.options` to see available build options. You'll probably
-want to select an `audio_backend`, at minimum. Be sure to reference Meson's
-[built-in options](https://mesonbuild.com/Builtin-options.html) for anything
-not covered here, like whether or not to emit optimized builds.
-
-> IMPORTANT: On Linux, you'll currently need to disable Meson's `b_asneeded` and
-`b_lundef` options, until we add a way to handle this kind of configuration for you.
-
-An example command sequence for building an optimized "release" build for Linux,
-using Clang:
+Some native environment config files are provided for the Meson build. You'll
+want to specify a build mode (`debug.ini`, `profiling.ini`, or `release.ini`,) 
+and a toolchain (`<os>-<tools>.ini`). Then, you can just `build` and `install`.
+Example:
 ```
-CXX=clang++ meson setup -Dbuildtype=release -Db_asneeded=false -Db_lundef=false -Daudio_backend=jack -Dmidi_backend=alsa build
-meson compile -C build
-meson install -C build
-```
-
-An example command sequence for building a "debug" build on Windows, using MSVC:
-```
-meson setup -Dbuildtype=debug -Daudio_backend=wasapi build
+meson setup --native-file build_native/win32-clang.ini --native-file build_native/debug.ini build
 meson compile -C build
 meson install -C build
 ```
@@ -66,3 +50,15 @@ meson install -C build
 If all goes well, you will then be able to run Mollytime like so:
 
  - `python mollytime`
+
+Note that any toolchain you request needs its binaries available on PATH,
+for both `setup` and `compile`.
+
+---
+
+If you want to configure manually instead, look at `meson.options` to see available
+build options. You'll probably want to select an `audio_backend`, at minimum.
+Be sure to reference Meson's [built-in options](https://mesonbuild.com/Builtin-options.html)
+for anything not covered here, like whether or not to emit optimized builds.
+
+> IMPORTANT: On Linux, you'll need to disable Meson's `b_asneeded` and `b_lundef` options.

--- a/build_native/debug.ini
+++ b/build_native/debug.ini
@@ -1,0 +1,6 @@
+[built-in options]
+buildtype = 'debug'
+
+[project options]
+boost_stacktrace = 'enabled'
+tracy = 'disabled'

--- a/build_native/linux-clang.ini
+++ b/build_native/linux-clang.ini
@@ -1,0 +1,8 @@
+[binaries]
+cpp = 'clang++'
+
+[project options]
+b_asneeded = false
+b_lundef = false
+audio_backend = 'jack'
+midi_backend = 'alsa'

--- a/build_native/linux-gcc.ini
+++ b/build_native/linux-gcc.ini
@@ -1,0 +1,8 @@
+[binaries]
+cpp = 'g++'
+
+[project options]
+b_asneeded = false
+b_lundef = false
+audio_backend = 'jack'
+midi_backend = 'alsa'

--- a/build_native/profiling.ini
+++ b/build_native/profiling.ini
@@ -1,0 +1,6 @@
+[built-in options]
+buildtype = 'debugoptimized'
+
+[project options]
+boost_stacktrace = 'enabled'
+tracy = 'enabled'

--- a/build_native/release.ini
+++ b/build_native/release.ini
@@ -1,0 +1,6 @@
+[built-in options]
+buildtype = 'release'
+
+[project options]
+boost_stacktrace = 'disabled'
+tracy = 'disabled'

--- a/build_native/win32-clang.ini
+++ b/build_native/win32-clang.ini
@@ -1,0 +1,11 @@
+[binaries]
+cpp = 'clang++.exe'
+cpp_ld = 'lld'
+ar = 'llvm-ar.exe'
+
+[built-in options]
+vsenv = false
+
+[project options]
+audio_backend = 'wasapi'
+midi_backend = 'none'

--- a/build_native/win32-msvc.ini
+++ b/build_native/win32-msvc.ini
@@ -1,0 +1,11 @@
+[binaries]
+cpp = 'cl.exe'
+cpp_ld = 'link'
+ar = 'lib.exe'
+
+[built-in options]
+vsenv = true
+
+[project options]
+audio_backend = 'wasapi'
+midi_backend = 'none'

--- a/meson.build
+++ b/meson.build
@@ -17,11 +17,9 @@ library_dirs = []
 dependencies = []
 source_files = []
 
-# We'll need to link `dl` (dynamic linking) and `m` (math) on non-Windows.
-if build_machine.system() != 'windows'
-    dependencies += compiler.find_library('m')
-    dependencies += compiler.find_library('dl')
-endif
+# We'll need to link `m` (math) `dl` (dynamic linking) on non-Windows.
+dependencies += compiler.find_library('m', required : false)
+dependencies += compiler.find_library('dl', required : false)
 
 # ---
 # Warning wrangling 🤠

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,6 @@ compiler = meson.get_compiler('cpp')
 project_dir = meson.project_source_root()
 
 include_dirs = []
-library_dirs = []
 dependencies = []
 source_files = []
 
@@ -45,15 +44,6 @@ endif
 python_install = py.find_installation()
 python = python_install.full_path()
 
-# On Windows, we need an explicit path to the Python static library directory, for pybind11.
-if build_machine.system() == 'windows'
-    base_prefix_command = run_command(python, '-c', 'import sys; print(sys.base_prefix)', check : true)
-    base_prefix = base_prefix_command.stdout().strip()
-    python_libs_path = base_prefix / 'libs'
-    library_dirs += f'-L@python_libs_path@'
-    message(f'Python `libs` directory: "@python_libs_path@"')
-endif
-
 # ---
 # GLM
 
@@ -64,22 +54,6 @@ include_dirs += include_directories(glm_include)
 # Pybind11
 
 dependencies += dependency('pybind11')
-
-# Windows doesn't (easily) provide `python3-config`, so pybind11 produces an equivalent for getting the `--extension-suffix`.
-# ...On Windows only. It omits this elsewhere, so we've got to change which one we're invoking depending on platform.
-if build_machine.system() == 'windows'
-    python_suffix_command_args = [ python, '-m', 'pybind11', '--extension-suffix' ]
-else
-    python_suffix_command_args = [ 'python3-config', '--extension-suffix' ]
-endif
-
-pybind_suffix_command = run_command(python_suffix_command_args, check : true)
-pybind_suffix = pybind_suffix_command.stdout().strip()
-
-# This extension suffix includes the leading `.`, but Meson wants to add this itself.
-if pybind_suffix.startswith('.')
-    pybind_suffix = pybind_suffix.substring(1)
-endif
 
 # ---
 # Audio backend
@@ -102,7 +76,6 @@ endif
 
 # ---
 # Stack trace
-
 
 use_boost_stacktraces = get_option('boost_stacktrace').enabled()
 if use_boost_stacktraces
@@ -158,14 +131,11 @@ source_files += [
     'src/wasapi_stream.cpp'
 ]
 
-shared_library(
+python_install.extension_module(
     'mollytime',
     source_files,
-    name_prefix : '',
-    name_suffix : pybind_suffix,
     include_directories : include_dirs,
-    link_args : library_dirs,
     dependencies : dependencies,
     install : true,
-    install_dir : project_dir / 'mollytime'
+    subdir : project_dir / 'mollytime'
 )

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project('mollytime', 'cpp',
     ]
 )
 
+fs = import('fs')
 py = import('python')
 
 compiler = meson.get_compiler('cpp')
@@ -102,19 +103,25 @@ endif
 # ---
 # Stack trace
 
-# Ideally, we can grab Boost as a system-known dependency. (Meson has internal magic for this.)
-# If not -- i.e, on Windows -- we'll look for a fallback in the `third_party` directory.
 
-if get_option('boost_stacktrace').enabled()
+use_boost_stacktraces = get_option('boost_stacktrace').enabled()
+if use_boost_stacktraces
+    # Ideally, we can grab Boost as a system-known dependency. (Meson has internal magic for this.)
     boost_stacktrace = dependency('boost', required : false)
-    if boost_stacktrace.found()
-        dependencies += boost_stacktrace
-    elif get_option('boost_stacktrace').enabled()
+    if not boost_stacktrace.found()
+        # If not -- i.e, on Windows -- we'll look for a fallback in the `third_party` directory.
         boost_stacktrace_dir = 'third_party' / 'boost-stacktrace-1.89.0'
-        include_dirs += include_directories(boost_stacktrace_dir / 'include')
-        message(f'boost_stacktrace: Fallback found: "@boost_stacktrace_dir@"')
+        if not fs.exists(boost_stacktrace_dir)
+            # If that's not there either, go ahead and let the build through; this isn't key functionality.
+            use_boost_stacktraces = false
+        else
+            include_dirs += include_directories(boost_stacktrace_dir / 'include')
+            message(f'boost_stacktrace: Fallback found: "@boost_stacktrace_dir@"')
+        endif
     endif
+endif
 
+if use_boost_stacktraces
     add_project_arguments('-DENABLE_STACK_TRACES=1', language : 'cpp')
     if build_machine.system() == 'windows'
         add_project_arguments('-DBOOST_STACKTRACE_USE_WINDBG=1', language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,6 @@ project('mollytime', 'cpp',
     ]
 )
 
-fs = import('fs')
 py = import('python')
 
 compiler = meson.get_compiler('cpp')
@@ -63,27 +62,7 @@ include_dirs += include_directories(glm_include)
 # ---
 # Pybind11
 
-pybind_includes_command = run_command(python, '-m', 'pybind11', '--includes', check : true)
-pybind_include_string = pybind_includes_command.stdout().strip()
-
-# `pybind11 --includes` returns whitespace-separated, GCC-style `-I` syntax.
-# We need to extract each path as a separate item, with no prefix.
-foreach include : pybind_include_string.split(' ')
-    include = include.strip()
-
-    # Remove -I prefix.
-    if include.startswith('-I')
-        include = include.substring(2)
-    endif
-
-    # Meson doesn't accept absolute paths that point inside the project directory.
-    # Make any such paths relative before including.
-    if include.startswith(project_dir)
-        include = fs.relative_to(include, project_dir)
-    endif
-    include_dirs += include_directories(include)
-    message(f'Pybind11 include directory: "@include@"')
-endforeach
+dependencies += dependency('pybind11')
 
 # Windows doesn't (easily) provide `python3-config`, so pybind11 produces an equivalent for getting the `--extension-suffix`.
 # ...On Windows only. It omits this elsewhere, so we've got to change which one we're invoking depending on platform.
@@ -96,7 +75,7 @@ endif
 pybind_suffix_command = run_command(python_suffix_command_args, check : true)
 pybind_suffix = pybind_suffix_command.stdout().strip()
 
-# `pybind11 --extension-suffix` includes the leading `.`, but Meson wants to add this itself.
+# This extension suffix includes the leading `.`, but Meson wants to add this itself.
 if pybind_suffix.startswith('.')
     pybind_suffix = pybind_suffix.substring(1)
 endif

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -922,35 +922,35 @@ struct TopologyPreservingTransformStateVariableFilterThunk : public InstructionT
         StateVar_z1_A->Set(gCoeff * HP + BP);
         StateVar_z2_A->Set(gCoeff * BP + LP);
 
-        if (Mode == FilterType::Lowpass)
+        if constexpr (Mode == FilterType::Lowpass)
         {
             Output->Set(LP);
         }
-        else if (Mode == FilterType::Bandpass)
+        else if constexpr (Mode == FilterType::Bandpass)
         {
             Output->Set(BP);
         }
-        else if (Mode == FilterType::Highpass)
+        else if constexpr (Mode == FilterType::Highpass)
         {
             Output->Set(HP);
         }
-        else if (Mode == FilterType::UnitGainBandpass)
+        else if constexpr (Mode == FilterType::UnitGainBandpass)
         {
             Output->Set(UBP);
         }
-        else if (Mode == FilterType::BandShelving)
+        else if constexpr (Mode == FilterType::BandShelving)
         {
             Output->Set(BShelf);
         }
-        else if (Mode == FilterType::Notch)
+        else if constexpr (Mode == FilterType::Notch)
         {
             Output->Set(Notch);
         }
-        else if (Mode == FilterType::Allpass)
+        else if constexpr (Mode == FilterType::Allpass)
         {
             Output->Set(AP);
         }
-        else if (Mode == FilterType::Peak)
+        else if constexpr (Mode == FilterType::Peak)
         {
             Output->Set(Peak);
         }

--- a/src/wasapi_stream.cpp
+++ b/src/wasapi_stream.cpp
@@ -107,8 +107,8 @@ void WasapiRealTimeThread::BeginFrame(FramePointers& Frame)
     assert(BufferState != nullptr);
 
     WasapiThreadShared& WasapiBufferState = static_cast<WasapiThreadShared &>(*BufferState);
-    assert(WasapiBufferState.OutputSamplesLeft.size() >= Frame.SampleCount);
-    assert(WasapiBufferState.OutputSamplesRight.size() >= Frame.SampleCount);
+    assert(std::ssize(WasapiBufferState.OutputSamplesLeft) >= Frame.SampleCount);
+    assert(std::ssize(WasapiBufferState.OutputSamplesRight) >= Frame.SampleCount);
 
     Frame.OutLeft = WasapiBufferState.OutputSamplesLeft.data();
     Frame.OutRight = WasapiBufferState.OutputSamplesRight.data();


### PR DESCRIPTION
1. Add some [native environment config files](https://mesonbuild.com/Native-environments.html) for the Meson build, so you don't have to keep passing options & environment variables. (A good followup would be to add [cross-compilation](https://mesonbuild.com/Cross-compilation.html) config files too, likely in `build_cross` or somesuch.)

2. Resolve a few build issues that came up after some further use:
    - Simplify resolving Linux static libraries.
    - Fix issues acquiring `pybind11` paths. Turns out Meson can just link this as a first-class `dependency`. Cool!
    - Use Meson's dedicated `extension_module` feature to dramatically simplify Python wrangling, a feature I totally knew about and whose built-in functionality I most definitely did not idiotically duplicate up until now.
    - Fix some new (and/or overlooked) compiler warnings.

NOTE: The Linux config files are untested, but that's never stopped anything from working, right?