### PR TITLE
Switch to editable install for development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ please let me know and I'll write them down here.
 
 ## "I want to work on / quickly try out the project!"
 
-Run these:
+Run this:
 - `python mollybuild.py setup <mode> <toolchain>`
-- `python mollybuild.py build`
 
-That's it. The C++ extension module will be placed directly alongside the Python
-source files, so you can just run `python -m mollytime` to test, and rerun `build`
-only when you change C++ source code.
+That's it! Now just run `python -m mollytime` to launch the project. When you do,
+the C++ extension module will be automatically recompiled if you've changed any
+source files since the last run..
 
 You can see supported `<mode>`s and `<toolchain>`s by checking command help:
 - `python mollybuild.py setup -h`
@@ -74,6 +73,7 @@ Mollytime uses the [Meson](https://mesonbuild.com/) build system, and leverages
 
 If you'd prefer to build "manually," you'll need to install these dependencies:
 - `pip install meson`
+- `pip install meson-python`
 - `pip install ninja`
 - `pip install pybind11`
 - `pip install pygame`
@@ -83,22 +83,26 @@ Native environment config files are provided for the Meson build, in `build_nati
 You'll want to specify a build mode (`mode-<mode>.ini`), and a toolchain
 (`toolchain-<os>-<tools>.ini`).
 
-For an iterative development workflow, specify `-Dworkflow=development` on `setup`.
-Then, you can just `compile` and `install` to place the extension module next to
-the project's Python source files. Example:
+For an iterative development workflow, run `pip install` for an editable wheel:
 ```
-meson setup -Dworkflow=development --native-file=build_native/win32-clang.ini --native-file=build_native/debug.ini build
-meson compile -C build
-meson install -C build
+pip install
+    -Ceditable-verbose=true
+    -Csetup-args=--native-file=<absolute>/<path>/<to>/build_native/<toolchain>.ini
+    -Csetup-args=--native-file=<absolute>/<path>/<to>/build_native/<mode>.ini
+    --editable .
 ```
 
 If all goes well, you will then be able to run Mollytime like so:
  - `python -m mollytime`
 
 To package, run this lovely incantation, with your toolchain of choice:
-- `python -m build -Csetup-args=-Dworkflow=packaging -Csetup-args=--native-file=<absolute_path_to>/build_native/release.ini -Csetup-args=--native-file=<absolute_path_to>/build_native/<toolchain>.ini`
+```
+python -m build
+    -Csetup-args=--native-file=<absolute>/<path>/<to>/build_native/release.ini
+    -Csetup-args=--native-file=<absolute>/<path>/<to>/build_native/<toolchain>.ini`
+```
 
-Yes, you do need absolute paths.
+Yes, you do need absolute paths for both.
 
 ## "I don't even want to use the native .ini files! I'll configure it all myself!"
 

--- a/meson.build
+++ b/meson.build
@@ -173,50 +173,31 @@ data_files = [
 ]
 
 # ---
-# Final outputs
+# Targets
 
-# Development workflow. "I'm actively iterating on the project. I want you to compile the cpp module as
-# as fast as possible, and then put it right next to the Python source, where I can run and debug
-# without any additional fuss."
-if get_option('workflow') == 'development'
-    # Compile and install the extension module directly to `mollytime/`.
-    python_install.extension_module(
-        'mollytime',
-        source_files,
-        include_directories : include_dirs,
-        dependencies : dependencies,
-        install : true,
-        install_dir : project_dir / 'mollytime'
-    )
+# Compile and install the extension module in `<install root>/mollytime/`.
+python_install.extension_module(
+    'mollytime',
+    source_files,
+    include_directories : include_dirs,
+    dependencies : dependencies,
+    install : true,
+    subdir : 'mollytime'
+)
 
-# Packaging workflow. "I want to produce a clean, complete, release-mode sdist and wheel for
-# distributing the project. It can take as long as it needs."
-elif get_option('workflow') == 'packaging'
-    # Compile and install the extension module in `<packaging root>/mollytime/`.
-    python_install.extension_module(
-        'mollytime',
-        source_files,
-        include_directories : include_dirs,
-        dependencies : dependencies,
-        install : true,
-        subdir : 'mollytime'
-    )
+# Install the Python source files in `<install root>/<source file path>`, preserving
+# relative directories. This means that e.g. `mollytime/screens/calc.py` will map to
+# `<install root>/mollytime/screens/calc.py`.
+python_install.install_sources(
+    python_files,
+    preserve_path : true
+)
 
-    # Install the Python source files in `<packaging root>/<source file path>`, preserving
-    # relative directories. This means that e.g. `mollytime/screens/calc.py` will map to
-    # `<packaging root>/mollytime/screens/calc.py`.
-    python_install.install_sources(
-        python_files,
-        preserve_path : true
-    )
-
-    # Install the data files in `<packaging root>/<source file path>`, preserving relative
-    # directories. This means that e.g. `mollytime/media/national_park/NationalPark-Bold.ttf`
-    # will map to `<packaging root>/mollytime/media/national_park/NationalPark-Bold.ttf`.
-    install_data(
-        data_files,
-        install_dir : python_install.get_install_dir(),
-        preserve_path : true
-    )
-
-endif
+# Install the data files in `<install root>/<source file path>`, preserving relative
+# directories. This means that e.g. `mollytime/media/national_park/NationalPark-Bold.ttf`
+# will map to `<install root>/mollytime/media/national_park/NationalPark-Bold.ttf`.
+install_data(
+    data_files,
+    install_dir : python_install.get_install_dir(),
+    preserve_path : true
+)

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,3 @@
-option('workflow', type : 'combo', choices: ['development', 'packaging'], value: 'development')
 option('audio_backend', type : 'combo', choices: ['none', 'jack', 'wasapi'])
 option('midi_backend', type : 'combo', choices: ['none', 'alsa'])
 option('boost_stacktrace', type : 'feature', value : 'auto')

--- a/mollybuild.py
+++ b/mollybuild.py
@@ -12,41 +12,39 @@ def _get_dependencies(dependencies: list[str]):
 
 def setup(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
     # Grab dependencies.
-    pip_result = _get_dependencies([ "meson", "ninja", "pybind11", "pygame" ])
+    pip_result = _get_dependencies([ "meson", "meson-python", "ninja", "pybind11", "pygame" ])
     if pip_result != 0:
         return pip_result
 
-    # Prepare to execute `meson setup`.
+    # Prepare to execute a local, editable `pip install`.
+    # This will have meson-python automatically run `meson setup`, and then add a launcher shim
+    # that automatically recompiles our extension module(s) when running the module locally.
     args_dict = vars(args)
-    setup_args = [ "meson", "setup", "-Dworkflow=development" ]
+    install_args = [ sys.executable, "-m", "pip", "install", "--no-build-isolation" ]
+
+    # This isn't that "verbose," it's just the normal `meson compile` output.
+    # We really need this, because it includes compile errors!
+    install_args += [ "-Ceditable-verbose=true" ]
     
     # Gather mode config, if specified.
     mode_name = args_dict.get("mode", None)
     if mode_name != None:
         mode_file = modes.get(mode_name, None)
         if mode_file != None:
-            setup_args += [ "--native-file", str(mode_file.resolve()) ]
+            mode_arg = f"--native-file={mode_file.resolve()}"
+            install_args += [ f"-Csetup-args={mode_arg}" ]
     
     # Gather toolchain config, if specified.
     toolchain_name = args_dict.get("toolchain", None)
     if toolchain_name != None:
         toolchain_file = toolchains.get(toolchain_name, None)
         if toolchain_file != None:
-            setup_args += [ "--native-file", str(toolchain_file.resolve()) ]
+            toolchain_arg = f"--native-file={toolchain_file.resolve()}"
+            install_args += [ f"-Csetup-args={toolchain_arg}" ]
     
     # Go.
-    setup_args += [ "build" ]
-    setup_result = subprocess.run(setup_args)
-    return setup_result.returncode
-
-def build(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
-    # Compile.
-    compile_result = subprocess.run([ "meson", "compile", "-C", "build" ])
-    if compile_result.returncode != 0:
-        return compile_result.returncode
-
-    # If successful, install.
-    install_result = subprocess.run([ "meson", "install", "--no-rebuild", "-C", "build" ])
+    install_args += [ "--editable", "." ]
+    install_result = subprocess.run(install_args)
     return install_result.returncode
 
 def package(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
@@ -102,14 +100,14 @@ if __name__ == "__main__":
         prog = "mollybuild",
         description = \
             "Concise build helper."
-            "\nFor an iterative 'development' workflow, run `setup`, then `build`."
+            "\nFor an iterative 'development' workflow, run `setup`, then just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run."
             "\nWhen you're ready to distribute, run `package`.",
         argument_default = "-h"
     )
     subparsers = parser.add_subparsers(title = "Commands")
 
     # `setup` command
-    setup_parser = subparsers.add_parser("setup", help = "Development: Set up a development build environment.")
+    setup_parser = subparsers.add_parser("setup", help = "Development: Set up a development build environment. Once complete, you can just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run.")
     setup_parser.set_defaults(command = setup)
     setup_parser.add_argument(
         "mode",
@@ -121,10 +119,6 @@ if __name__ == "__main__":
         help = "Toolchain to build with. If unspecified, uses your system default, which might not be in this list.",
         choices = toolchains.keys()
     )
-
-    # `build` command
-    build_parser = subparsers.add_parser("build", help = "Development: Execute the build environment created by `setup`.")
-    build_parser.set_defaults(command = build)
 
     # `package` command
     package_parser = subparsers.add_parser("package", help = "Release: Build a distributable Python package (sdist and wheel).")


### PR DESCRIPTION
This is the idiomatic way to iterate on Python packages for development, and is first-class supported by meson-python, dramatically simplifying our build pipeline at no cost to efficiency -- an improvement, in fact.

Now, to develop the project, simply set up your Python environment, and run:
- `py(thon) mollybuild.py setup <mode> <toolchain>`, for one-time setup.
- `py(thon) -m mollytime`, to run the project. This will automatically invoke `meson compile`, rebuilding if source files have changed, and backing out w/ the error output if that fails.

Cool! Here's what's happening:
- `pip install --no-build-isolation --editable .` is installing the `pyproject.toml` into your local site-packages as a stub, which magically redirects to your source files. This means the module is invoked as a Proper Installed Module in most respects, but is executing your source files, and therefore picking up local changes.
- Meson-python builds off this by adding a launcher shim that invokes `meson compile` (only) when this stub is launched, ensuring that C++ source files are recompiled first. We need to specify "verbose" output to get the error report if this fails -- don't worry, it's not actually verbose, it's just the standard `meson compile` output.

This means `mollybuild.py`'s `build` command is no longer needed, and can be removed. Likewise, this means we no longer need the "workflow" option hack, which can also be removed. Look at how simple the build file has become!

Two notes:
- Local development still requires `pip install`ing build dependencies locally, but `mollybuild.py` continues to take care of this for you. Just keep it in mind if you want to clean up afterward. Note that it *doesn't* require installing runtime dependencies (pygame) -- pip will actually take care of that as part of the setup process.
- Debuggers will get weird about the launcher shim if your virtual environment isn't absolutely-definitely active when the debugger starts. If (like me) VS Code or whatever is giving you trouble, explicitly add your venv's Scripts directory to PATH when launching the debugger.