### PR TITLE
Add a Pyinstaller target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,3 @@ __pycache__/
 build/
 dist/
 .mesonpy*/
-
-.venv/
-.vscode/
-.clinkscales/
-clinkbuild.bat

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ __pycache__/
 *.pyd
 *.kate-swp
 build/
+dist/
+.mesonpy*/
+
+.venv/
+.vscode/
+.clinkscales/
+clinkbuild.bat

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ You can see supported `<mode>`s and `<toolchain>`s by checking command help:
 If you omit the toolchain, it'll detect your system "default." This might work
 even if your system default isn't on the supported list, but it might not.
 
+## "I want to build a 'exe'!"
+
+After `setup`, run this:
+- `python mollybuild.py exe`
+
+This uses [Pyinstaller](https://pyinstaller.org/) to bundle the project & its
+dependencies into a single-file executable, output to a `dist` subfolder.
+
 ## "I want to package the project for distribution!"
 
 Run this:
@@ -76,6 +84,7 @@ If you'd prefer to build "manually," you'll need to install these dependencies:
 - `pip install meson-python`
 - `pip install ninja`
 - `pip install pybind11`
+- `pip install pyinstaller`
 - `pip install pygame`
 - `pip install build`
 
@@ -90,6 +99,7 @@ pip install
     -Csetup-args=--native-file=<absolute>/<path>/<to>/build_native/toolchain-<toolchain>.ini
     -Csetup-args=--native-file=<absolute>/<path>/<to>/build_native/mode-<mode>.ini
     -Csetup-args=-Dbuildtype=<mode>
+    -Ccompile-args=-mollytime<python-extension-suffix>
     --editable .
 ```
 
@@ -97,9 +107,17 @@ pip install
 > meson-python: its [built-in option overrides](https://mesonbuild.com/meson-python/explanations/default-options.html)
 > are hardcoded as CLI args, meaning they always take priority over our native files.
 > We have to claim even-higher priority by passing in our own CLI override.
+>
+> Further note the need for an extension suffix on the the `compiler-args`. Without this,
+> meson-python will unnecessarily build the Pyinstaller target, wasting a minute or more of
+> time. Getting that suffix is up to you; or just omit the args, if you don't mind the wait.
 
 If all goes well, you will then be able to run Mollytime like so:
  - `python -m mollytime`
+
+To build an executable, compile & install the target through the Meson project:
+- `meson compile -C <the build dir> mollytime-exe`
+- `meson install -C <the build dir> --tags=exe`
 
 To package, run this lovely incantation, with your toolchain of choice:
 ```

--- a/meson.build
+++ b/meson.build
@@ -108,7 +108,7 @@ if get_option('tracy').enabled()
     tracy_dir = 'third_party' / 'tracy-0.12.2' / 'public'
     add_project_arguments('-DTRACY_ENABLE', language: 'cpp')
     include_dirs += include_directories(tracy_dir)
-    source_files += tracy_dir / 'TracyClient.cpp'
+    source_files += files(tracy_dir / 'TracyClient.cpp')
 
     if build_machine.system() != 'windows'
         dependencies += dependency('threads')
@@ -118,7 +118,7 @@ endif
 # ---
 # File lists
 
-source_files += [
+source_files += files(
     'src' / 'alsa_midi.cpp',
     'src' / 'audio_backend.cpp',
     'src' / 'colors.cpp',
@@ -130,9 +130,9 @@ source_files += [
     'src' / 'perf.cpp',
     'src' / 'py_api.cpp',
     'src' / 'wasapi_stream.cpp'
-]
+)
 
-python_files = [
+python_files = files(
     'mollytime' / '__init__.py',
     'mollytime' / '__main__.py',
     'mollytime' / 'colors.py',
@@ -151,9 +151,9 @@ python_files = [
     'mollytime' / 'screens' / 'pick_and_place.py',
     'mollytime' / 'screens' / 'scope.py',
     'mollytime' / 'screens' / 'select.py'
-]
+)
 
-data_files = [
+data_files = files(
     'mollytime' / 'media' / 'afacad' / 'Afacad-Italic-VariableFont_wght.ttf',
     'mollytime' / 'media' / 'afacad' / 'Afacad-VariableFont_wght.ttf',
     'mollytime' / 'media' / 'afacad' / 'static' / 'Afacad-Bold.ttf',
@@ -171,7 +171,7 @@ data_files = [
     'mollytime' / 'media' / 'national_park' / 'NationalPark-Medium.ttf',
     'mollytime' / 'media' / 'national_park' / 'NationalPark-Regular.ttf',
     'mollytime' / 'media' / 'national_park' / 'NationalPark-SemiBold.ttf',
-]
+)
 
 # ---
 # Targets

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,16 @@ source_files = []
 dependencies += compiler.find_library('m', required : false)
 dependencies += compiler.find_library('dl', required : false)
 
+# HACK: Apparently Meson doesn't actually offer a way for us to get a platform's
+# executable suffix...? It absolutely knows about this, and has this internally. See:
+# - https://github.com/mesonbuild/meson/blob/8bba5d0a80ece5c14f5e56468dcf50752fe5d46d/mesonbuild/build.py#L2152
+# - https://github.com/mesonbuild/meson/blob/master/mesonbuild/envconfig.py#L382
+if build_machine.system() == 'windows'
+    executable_suffix = '.exe'
+else
+    executable_suffix = ''
+endif
+
 # ---
 # Warning wrangling 🤠
 
@@ -54,6 +64,12 @@ include_dirs += include_directories(glm_include)
 # Pybind11
 
 dependencies += dependency('pybind11')
+
+# ---
+# Pyinstaller
+
+pyi_makespec = find_program('pyi-makespec', required : true)
+pyinstaller = find_program('pyinstaller', required : true)
 
 # ---
 # Audio backend
@@ -177,12 +193,13 @@ data_files = files(
 # Targets
 
 # Compile and install the extension module in `<install root>/mollytime/`.
-python_install.extension_module(
+cpp_module = python_install.extension_module(
     'mollytime',
     source_files,
     include_directories : include_dirs,
     dependencies : dependencies,
     install : true,
+    install_tag : 'package',
     subdir : 'mollytime'
 )
 
@@ -191,6 +208,7 @@ python_install.extension_module(
 # `<install root>/mollytime/screens/calc.py`.
 python_install.install_sources(
     python_files,
+    install_tag : 'package',
     preserve_path : true
 )
 
@@ -200,5 +218,44 @@ python_install.install_sources(
 install_data(
     data_files,
     install_dir : python_install.get_install_dir(),
+    install_tag : 'package',
     preserve_path : true
+)
+
+# Generate a pyinstaller spec file on `setup`.
+cpp_module_source = cpp_module.full_path()
+cpp_module_target_dir = 'mollytime'
+media_dir_source = project_dir / 'mollytime' / 'media'
+media_dir_target = 'mollytime' / 'media'
+
+run_command(
+    pyi_makespec,
+    '--onefile',
+    '--specpath', meson.project_build_root(),
+    '--name', 'mollytime',
+    '--icon', project_dir / 'mollytime.ico',
+    '--add-binary', cpp_module_source + ':' + cpp_module_target_dir,
+    '--add-data', media_dir_source + ':' + media_dir_target,
+    project_dir / 'pyinstaller_main.py',
+    check : true
+)
+
+# Create a build target for pyinstaller, installed separately from our `package` targets.
+spec_file = files(meson.project_build_root() / 'mollytime.spec')
+
+custom_target(
+    'mollytime-exe',
+    command : [
+        pyinstaller,
+        '--workpath', '@PRIVATE_DIR@',
+        '--distpath', '@OUTDIR@',
+        '@INPUT@'
+    ],
+    input : [ spec_file ],
+    output : 'mollytime' + executable_suffix,
+    depend_files : python_files + data_files,
+    depends : [ cpp_module ],
+    install : true,
+    install_dir: project_dir / 'dist',
+    install_tag : 'exe'
 )

--- a/mollybuild.py
+++ b/mollybuild.py
@@ -1,6 +1,8 @@
 import os
+import platform
 import subprocess
 import sys
+import sysconfig
 
 from argparse import ArgumentParser, Namespace
 from configparser import ConfigParser
@@ -47,7 +49,7 @@ def _HACK_extract_override_overrides(native_file: Path) -> list[str]:
 
 def setup(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
     # Grab dependencies.
-    pip_result = _get_dependencies([ "meson", "meson-python", "ninja", "pybind11", "pygame" ])
+    pip_result = _get_dependencies([ "meson", "meson-python", "ninja", "pybind11", "pyinstaller", "pygame" ])
     if pip_result != 0:
         return pip_result
 
@@ -79,8 +81,34 @@ def setup(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
             install_args += [ f"-Csetup-args={toolchain_arg}" ]
             install_args += _HACK_extract_override_overrides(toolchain_file)
     
+    # Only compile targets that are useful for an editable install (i.e. not pyinstaller).
+    extension_module_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    editable_target_names = ( f"mollytime{extension_module_suffix}", )
+    
+    for target_name in editable_target_names:
+        install_args += [ f"-Ccompile-args={target_name}"]
+
     # Go.
-    install_args += [ "--editable", "." ]
+    install_args += [ "-v", "--editable", "." ]
+    install_result = subprocess.run(install_args)
+    return install_result.returncode
+
+def exe(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
+    # Get the build directory. Meson-python will set this to './build/cpXX`,
+    # where XX is the Python major & minor version number, w/o decimal separators.
+    major, minor, _ = platform.python_version().split(".")
+    build_dir_local = Path("build") / f"cp{major}{minor}"
+
+    # If this doesn't exist, the user probably forgot to run `setup`.
+    this_dir = Path(__file__).parent
+    build_dir = this_dir / build_dir_local
+    if not build_dir.exists():
+        print(f"Error: I can't find the expected build directory: '{build_dir_local}' (i.e. '{build_dir}').\nDid you forget to run `setup`?")
+        return 1
+    
+    # Invoke `meson install` on the pyinstaller target only. This will trigger
+    # a recompile, if needed.
+    install_args = [ "meson", "install", "--tags=exe", "-C", str(build_dir.resolve()) ]
     install_result = subprocess.run(install_args)
     return install_result.returncode
 
@@ -92,8 +120,7 @@ def package(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace
 
     # Prepare to execute `py(thon) -m build`.
     args_dict = vars(args)
-    workflow_arg = "-Dworkflow=packaging"
-    setup_args = [ sys.executable, "-m", "build", f"-Csetup-args={workflow_arg}" ]
+    setup_args = [ sys.executable, "-m", "build" ]
 
     # Always package in `release` mode.
     mode_file = modes["release"]
@@ -165,6 +192,10 @@ if __name__ == "__main__":
         help = "Toolchain to build with. If unspecified, uses your system default.",
         choices = toolchains.keys()
     )
+
+    # `exe` command
+    exe_parser = subparsers.add_parser("exe", help = "Release: Build an executable with Pyinstaller. You'll need to run `setup` first.")
+    exe_parser.set_defaults(command = exe)
 
     # Go
     args = parser.parse_args()

--- a/mollytime/__main__.py
+++ b/mollytime/__main__.py
@@ -31,125 +31,132 @@ from .patterns import *
 from .screens.common import program_card
 from .screens.inspect import inspect_screen
 
-operating_system = platform.system()
 
-if operating_system == "Windows":
-    import ctypes
-    # needed for highdpi to work correctly
-    ctypes.windll.user32.SetProcessDPIAware()
+def main():
+    operating_system = platform.system()
 
-mollytime.init_midi()
-mollytime.init_audio(48000)
-pygame.display.init()
-pygame.font.init()
+    if operating_system == "Windows":
+        import ctypes
+        # needed for highdpi to work correctly
+        ctypes.windll.user32.SetProcessDPIAware()
 
-dump_icon = False
-icon_size = 32
-if len(sys.argv) >= 2 and sys.argv[1] == "icon":
-    icon_size = int((sys.argv[2:] + ["256"])[0])
-    dump_icon = True
+    mollytime.init_midi()
+    mollytime.init_audio(48000)
+    pygame.display.init()
+    pygame.font.init()
 
-# According to the docs, the program icon must be set before calling "pygame.display.set_mode".
-# However this does not seem to do anything on Linux, probably due to Wayland nonsense to add security.
-program_icon = plate_bg(icon_size // 2, parse_color("#dee5e8"), "moll-\nytime")
-if dump_icon:
-    pygame.image.save(program_icon.surface, "mollytime.png")
-    exit()
+    print(sys.argv)
 
-else:
-    assert(program_icon.surface.get_rect().w == icon_size)
-    assert(program_icon.surface.get_rect().h == icon_size)
-    pygame.display.set_icon(program_icon.surface)
-    pygame.display.set_caption("mollytime")
+    dump_icon = False
+    icon_size = 32
+    if len(sys.argv) >= 2 and sys.argv[1] == "icon":
+        icon_size = int((sys.argv[2:] + ["256"])[0])
+        dump_icon = True
 
-display_index_arg, vertical_inches_arg = (sys.argv[1:] + [None, None])[:2]
-display_index = 0
-vertical_inches = 7.5
-skip_dpi_detection = False
+    # According to the docs, the program icon must be set before calling "pygame.display.set_mode".
+    # However this does not seem to do anything on Linux, probably due to Wayland nonsense to add security.
+    program_icon = plate_bg(icon_size // 2, parse_color("#dee5e8"), "moll-\nytime")
+    if dump_icon:
+        pygame.image.save(program_icon.surface, "mollytime.png")
+        exit()
 
-sizes = pygame.display.get_desktop_sizes()
-
-if display_index_arg is not None:
-    try:
-        override_display_index = int(display_index_arg)
-        assert(override_display_index > -1 and override_display_index < len(sizes))
-        display_index = override_display_index
-    except:
-        print(f"\"{display_index_arg}\" is not a valid display index.  Defaulting to \"{display_index}\".")
-
-if vertical_inches_arg is not None:
-    try:
-        override_vertical_inches = float(vertical_inches_arg)
-        assert(override_vertical_inches > 0)
-        vertical_inches = override_vertical_inches
-        skip_dpi_detection = True
-    except:
-        print(f"\"{vertical_inches_arg}\" is not a valid vertical distance.  Defaulting to \"{vertical_inches}\".")
-
-scaled_display_size = sizes[display_index]
-unscaled_display_size = pygame.display.list_modes(display=display_index)[0]
-
-window_flags = pygame.FULLSCREEN
-if operating_system == "Windows":
-    # opt into borderless fullscreen and prevent display mode setting:
-    window_flags |= pygame.SCALED
-
-screen = pygame.display.set_mode(size=unscaled_display_size, display=display_index, flags=window_flags)
-
-dpi = None
-
-if not skip_dpi_detection:
-    if operating_system == "Linux":
-        xrandr_dpi = None
-
-        xrandr = subprocess.run(("xrandr", "--listactivemonitors"), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        if xrandr.returncode == 0:
-            try:
-                report = xrandr.stdout.decode().split("\n")
-                regex = r'^Monitors: (\d)$'
-                found = re.findall(regex, report[0], re.M)
-                assert(len(found) == 1)
-                assert(int(found[0]) == len(sizes))
-
-                monitor_info = report[1 + display_index]
-                regex = r'^\s+(\d+):.+ (\d+)/(\d+)x(\d+)/(\d+)'
-                found = re.findall(regex, monitor_info, re.M)
-                assert(len(found) == 1)
-                reported_index, res_x, mm_x, res_y, mm_y = list(map(int, found[0]))
-                #print(f"monitor {display_index}: {res_x}x{res_y} ({mm_x}mm by {mm_y}mm)")
-
-                assert(len(found) == 1)
-
-                # xrandr may report the scaled or unscaled resolution, and so it cannot be relied upon for DPI calculation
-                res_x, res_y = sizes[display_index]
-
-                in_x = mm_x / 25.4
-                in_y = mm_y / 25.4
-                dpi_x = res_x / in_x
-                dpi_y = res_y / in_y
-                xrandr_dpi = round((dpi_x + dpi_y) / 2)
-            except AssertionError:
-                xrandr_dpi = None
-
-        if xrandr_dpi:
-            dpi = xrandr_dpi
-        else:
-            print("Unable to calculate screen DPI via xrandr!")
     else:
-        print("Unable to automatically determine the screen DPI!")
-else:
-    print("Automatic DPI detection skipped at operator request.")
+        assert(program_icon.surface.get_rect().w == icon_size)
+        assert(program_icon.surface.get_rect().h == icon_size)
+        pygame.display.set_icon(program_icon.surface)
+        pygame.display.set_caption("mollytime")
 
-if dpi is None:
-    in_y = vertical_inches
-    res_y = min(scaled_display_size)
-    dpi = round(res_y / in_y)
-    print(f"DPI assuming smallest physical screen dimension is {in_y} inches: {dpi} dpi")
+    display_index_arg, vertical_inches_arg = (sys.argv[1:] + [None, None])[:2]
+    display_index = 0
+    vertical_inches = 7.5
+    skip_dpi_detection = False
 
-dpi = int(dpi * (max(unscaled_display_size) / max(scaled_display_size)))
+    sizes = pygame.display.get_desktop_sizes()
 
-editor = program_card(screen, dpi)
-ui = inspect_screen(editor)
+    if display_index_arg is not None:
+        try:
+            override_display_index = int(display_index_arg)
+            assert(override_display_index > -1 and override_display_index < len(sizes))
+            display_index = override_display_index
+        except:
+            print(f"\"{display_index_arg}\" is not a valid display index.  Defaulting to \"{display_index}\".")
 
-mollytime.shutdown_audio()
-mollytime.shutdown_midi()
+    if vertical_inches_arg is not None:
+        try:
+            override_vertical_inches = float(vertical_inches_arg)
+            assert(override_vertical_inches > 0)
+            vertical_inches = override_vertical_inches
+            skip_dpi_detection = True
+        except:
+            print(f"\"{vertical_inches_arg}\" is not a valid vertical distance.  Defaulting to \"{vertical_inches}\".")
+
+    scaled_display_size = sizes[display_index]
+    unscaled_display_size = pygame.display.list_modes(display=display_index)[0]
+
+    window_flags = pygame.FULLSCREEN
+    if operating_system == "Windows":
+        # opt into borderless fullscreen and prevent display mode setting:
+        window_flags |= pygame.SCALED
+
+    screen = pygame.display.set_mode(size=unscaled_display_size, display=display_index, flags=window_flags)
+
+    dpi = None
+
+    if not skip_dpi_detection:
+        if operating_system == "Linux":
+            xrandr_dpi = None
+
+            xrandr = subprocess.run(("xrandr", "--listactivemonitors"), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            if xrandr.returncode == 0:
+                try:
+                    report = xrandr.stdout.decode().split("\n")
+                    regex = r'^Monitors: (\d)$'
+                    found = re.findall(regex, report[0], re.M)
+                    assert(len(found) == 1)
+                    assert(int(found[0]) == len(sizes))
+
+                    monitor_info = report[1 + display_index]
+                    regex = r'^\s+(\d+):.+ (\d+)/(\d+)x(\d+)/(\d+)'
+                    found = re.findall(regex, monitor_info, re.M)
+                    assert(len(found) == 1)
+                    reported_index, res_x, mm_x, res_y, mm_y = list(map(int, found[0]))
+                    #print(f"monitor {display_index}: {res_x}x{res_y} ({mm_x}mm by {mm_y}mm)")
+
+                    assert(len(found) == 1)
+
+                    # xrandr may report the scaled or unscaled resolution, and so it cannot be relied upon for DPI calculation
+                    res_x, res_y = sizes[display_index]
+
+                    in_x = mm_x / 25.4
+                    in_y = mm_y / 25.4
+                    dpi_x = res_x / in_x
+                    dpi_y = res_y / in_y
+                    xrandr_dpi = round((dpi_x + dpi_y) / 2)
+                except AssertionError:
+                    xrandr_dpi = None
+
+            if xrandr_dpi:
+                dpi = xrandr_dpi
+            else:
+                print("Unable to calculate screen DPI via xrandr!")
+        else:
+            print("Unable to automatically determine the screen DPI!")
+    else:
+        print("Automatic DPI detection skipped at operator request.")
+
+    if dpi is None:
+        in_y = vertical_inches
+        res_y = min(scaled_display_size)
+        dpi = round(res_y / in_y)
+        print(f"DPI assuming smallest physical screen dimension is {in_y} inches: {dpi} dpi")
+
+    dpi = int(dpi * (max(unscaled_display_size) / max(scaled_display_size)))
+
+    editor = program_card(screen, dpi)
+    ui = inspect_screen(editor)
+
+    mollytime.shutdown_audio()
+    mollytime.shutdown_midi()
+
+if __name__ == "__main__":
+    main()

--- a/mollytime/screens/common.py
+++ b/mollytime/screens/common.py
@@ -649,7 +649,7 @@ class editor_screen:
                 self.force_redraw = True
 
             elif event.type == pygame.QUIT:
-                exit(0)
+                sys.exit(0)
 
             # else:
             #     # attempt to determine what mystery events are

--- a/pyinstaller_main.py
+++ b/pyinstaller_main.py
@@ -1,0 +1,4 @@
+from mollytime.__main__ import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ readme = "README.md"
 dependencies = [
     "pygame"
 ]
+
+[tool.meson-python.args]
+install = [ "--tags=package" ]


### PR DESCRIPTION
This was conceptually simple, but in practice, a giant quagmire. The good news is that it now works very well, at zero compromise to the `mollybuild.py` workflow, and only minor compromise to the "manual" workflow of setting up an editable install.

For a detailed overview, see the commits, especially "Add Pyinstaller target to the build." Here are the basics:
- Pyinstaller is now integrated into the Meson build. A spec file is generated on setup, and executed as a custom target. This ensures that all prerequisites are (re)built when changed, and properly cached if unchanged.
- A launcher shim has been added to work around Pyinstaller's [long-standing inability](https://github.com/pyinstaller/pyinstaller/issues/2560) to resolve package-relative `__main__.py` imports. This extracts `__main__.py`'s logic into an importable function, but has no effect on its behavior outside of Pyinstaller use cases.
- You need to run `python mollybuild.py setup` to prepare the project. Then, build the exe by simply running `python mollybuild.py exe`. This handles all the path & target wrangling automatically.

The file will be output to `dist`, for you to use as you please.