### PR TITLE
Implement SDL audio backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ source_files = files(
     'src' / 'sdl_font.cpp',
     'src' / 'sdl_mouse.cpp',
     'src' / 'sdl_rect.cpp',
+    'src' / 'sdl_stream.cpp',
     'src' / 'sdl_time.cpp',
     'src' / 'thunks.cpp',
     'src' / 'wasapi_stream.cpp'
@@ -136,39 +137,13 @@ dependencies += dependency('pybind11', required : true)
 pyi_makespec = find_program('pyi-makespec', required : true)
 pyinstaller = find_program('pyinstaller', required : true)
 
-# Audio backend
-if get_option('audio_backend') == 'jack'
-    dependencies += declare_dependency(
-        compile_args : '-DENABLE_JACK=1',
-        dependencies : dependency('jack', required : true)
-    )
-elif get_option('audio_backend') == 'wasapi'
-    dependencies += declare_dependency(
-        compile_args : '-DAUDIO_WASAPI=1',
-        dependencies : compiler.find_library('RuntimeObject', required : true)
-    )
-endif
-
-# MIDI backend
-if get_option('midi_backend') == 'alsa'
-    dependencies += declare_dependency(
-        compile_args : '-DMIDI_ALSA=1',
-        dependencies : compiler.find_library('asound', required : true)
-    )
-elif get_option('midi_backend') == 'mmeapi'
-    dependencies += declare_dependency(
-        compile_args : '-DMIDI_MMEAPI=1',
-        dependencies : compiler.find_library('Winmm', required : true)
-    )   
-endif
-
 # fmt
 fmt_dir = 'third_party' / 'fmt-12.1.0'
 fmt_include = fmt_dir / 'include'
 fmt_include_dirs = include_directories(fmt_include)
 fmt_source_files = files(fmt_dir / 'src' / 'format.cc')
 
-dependencies += declare_dependency(
+fmt_dependency = declare_dependency(
     include_directories : fmt_include_dirs,
     link_with : static_library(
         'fmt',
@@ -176,13 +151,16 @@ dependencies += declare_dependency(
         include_directories : fmt_include_dirs,
         override_options : [ 'warning_level=0' ]
     )
-)
+) 
+dependencies += fmt_dependency
 
 # GLM
 glm_dir = 'third_party' / 'glm-1.0.3'
-dependencies += declare_dependency(
+
+glm_dependency = declare_dependency(
     include_directories : include_directories(glm_dir)
-)
+) 
+dependencies += glm_dependency
 
 # Tracy
 if get_option('tracy').enabled()
@@ -190,7 +168,7 @@ if get_option('tracy').enabled()
     tracy_include_dirs = include_directories(tracy_dir)
     tracy_source_files = files(tracy_dir / 'TracyClient.cpp')
     
-    dependencies += declare_dependency(
+    tracy_dependency = declare_dependency(
         compile_args : '-DTRACY_ENABLE',
         dependencies : dependency('threads', required : false),
         include_directories : tracy_include_dirs,
@@ -201,6 +179,7 @@ if get_option('tracy').enabled()
             override_options : 'warning_level=0'
         )
     )
+    dependencies += tracy_dependency
 endif
 
 # Boost
@@ -226,11 +205,11 @@ foreach line : boost_install_info
     endif
 endforeach
 
-dependencies += declare_dependency(
+boost_dependency = declare_dependency(
     compile_args : boost_compile_args,
     include_directories : include_directories(boost_include_dir),
 )
-
+dependencies += boost_dependency
 
 # SDL3
 sdl3_install_info_command = run_command(
@@ -253,10 +232,11 @@ foreach line : sdl3_install_info
     endif
 endforeach
 
-dependencies += declare_dependency(
+sdl_dependency = declare_dependency(
     include_directories : include_directories(sdl3_include_dir),
     dependencies : compiler.find_library('SDL3', dirs : project_dir / sdl3_library_dir)
 )
+dependencies += sdl_dependency
 
 if build_machine.system() == 'windows'
     fs.copyfile(sdl3_binary_dir / 'SDL3.dll')
@@ -283,13 +263,45 @@ foreach line : sdl3_ttf_install_info
     endif
 endforeach
 
-dependencies += declare_dependency(
+sdl_ttf_dependency = declare_dependency(
     include_directories : include_directories(sdl3_ttf_include_dir),
     dependencies : compiler.find_library('SDL3_ttf', dirs : project_dir / sdl3_ttf_library_dir)
 )
+dependencies += sdl_ttf_dependency
 
 if build_machine.system() == 'windows'
     fs.copyfile(sdl3_ttf_binary_dir / 'SDL3_ttf.dll')
+endif
+
+# Audio backend
+if get_option('audio_backend') == 'sdl'
+    dependencies += declare_dependency(
+        compile_args : '-DAUDIO_SDL=1',
+        dependencies : sdl_dependency
+    )
+elif get_option('audio_backend') == 'jack'
+    dependencies += declare_dependency(
+        compile_args : '-DENABLE_JACK=1',
+        dependencies : dependency('jack', required : true)
+    )
+elif get_option('audio_backend') == 'wasapi'
+    dependencies += declare_dependency(
+        compile_args : '-DAUDIO_WASAPI=1',
+        dependencies : compiler.find_library('RuntimeObject', required : true)
+    )
+endif
+
+# MIDI backend
+if get_option('midi_backend') == 'alsa'
+    dependencies += declare_dependency(
+        compile_args : '-DMIDI_ALSA=1',
+        dependencies : compiler.find_library('asound', required : true)
+    )
+elif get_option('midi_backend') == 'mmeapi'
+    dependencies += declare_dependency(
+        compile_args : '-DMIDI_MMEAPI=1',
+        dependencies : compiler.find_library('Winmm', required : true)
+    )   
 endif
 
 

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,4 @@
-option('audio_backend', type : 'combo', choices: ['none', 'jack', 'wasapi'])
+option('audio_backend', type : 'combo', choices: ['none', 'sdl', 'jack', 'wasapi'])
 option('midi_backend', type : 'combo', choices: ['none', 'alsa', 'mmeapi'])
 option('boost_stacktrace', type : 'feature', value : 'auto')
 option('tracy', type : 'feature', value: 'disabled')

--- a/src/audio_backend.cpp
+++ b/src/audio_backend.cpp
@@ -16,10 +16,13 @@
 #include "audio_backend.h"
 #include "midi.h"
 
-#if defined(ENABLE_JACK)
+#if defined(AUDIO_SDL)
+#include "sdl_stream.h"
+#elif defined(ENABLE_JACK)
 #include "jack_stream.h"
 #elif defined(AUDIO_WASAPI)
 #include "wasapi_stream.h"
+
 #endif
 
 #include <fmt/format.h>
@@ -162,7 +165,9 @@ AudioStream* Audio::GetStream()
 
 void Audio::Init(int SampleRate)
 {
-#if defined(ENABLE_JACK)
+#if defined(AUDIO_SDL)
+    Stream = std::make_unique<SDLStream>(SampleRate);
+#elif defined(ENABLE_JACK)
     Stream = std::make_unique<JackStream>(SampleRate);
 #elif defined(AUDIO_WASAPI)
     Stream = std::make_unique<WasapiStream>(SampleRate);

--- a/src/sdl_stream.cpp
+++ b/src/sdl_stream.cpp
@@ -129,7 +129,7 @@ void SDLRealTimeThread::EndFrame(FramePointers& Frame)
     // If this isn't fast enough, `SDL_PutAudioStreamDataNoCopy()` can read directly from an already-interleaved buffer,
     // but that means we'd have 1. do our own faster-than-SDL interleave, or 2. generate samples pre-interleaved.
     const float* SamplesLeft = SDLBufferState.OutputSamplesLeft.data();
-    const float* SamplesRight = SDLBufferState.OutputSamplesLeft.data();
+    const float* SamplesRight = SDLBufferState.OutputSamplesRight.data();
     const void* Channels[] = { SamplesLeft, SamplesRight };
 
     if(!SDL_PutAudioStreamPlanarData(SDLStream, Channels, 2, Frame.SampleCount))

--- a/src/sdl_stream.cpp
+++ b/src/sdl_stream.cpp
@@ -1,0 +1,162 @@
+// Copyright 2025 Aeva Palecek
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef AUDIO_SDL
+
+#include "sdl_stream.h"
+
+#include <fmt/format.h>
+#include <SDL3/SDL_init.h>
+#include <SDL3/SDL_audio.h>
+
+
+SDLRealTimeThread::SDLRealTimeThread(SDLThreadShared* SDLBufferState, int SampleRate)
+{
+    assert(SDLBufferState != nullptr);
+    assert(SampleRate >= 0);
+
+    // Up-the-chain init that we have to do here for some reason.
+    BufferState = SDLBufferState;
+    ResetFramePressure();
+    SampleInterval = 1.0 / double(SampleRate);
+
+    // SDL Audio must be initialized. If it's already initialized, this will harmlessly no-op.
+    if(!SDL_InitSubSystem(SDL_INIT_AUDIO))
+    {
+        throw std::runtime_error(fmt::format("Failed to initialize SDL Audio subsystem: {}", SDL_GetError()));
+    }
+
+    // Create an SDL audio stream with our given options. (Data format & stereo output are currently hardcoded.)
+    SDL_AudioSpec AudioSpec;
+    AudioSpec.channels = 2;
+    AudioSpec.format = SDL_AUDIO_F32;
+    AudioSpec.freq = SampleRate;
+
+    SDLStream = SDL_OpenAudioDeviceStream(
+        SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK,
+        &AudioSpec,
+        &SDLRealTimeThread::OnAudioRequested,
+        this
+    );
+    if(SDLStream == nullptr)
+    {
+        throw std::runtime_error(fmt::format("Failed to open SDL audio stream: {}", SDL_GetError()));
+    }
+
+    // This one-and-done API begins with a paused stream. We have to manually resume it.
+    if(!SDL_ResumeAudioStreamDevice(SDLStream))
+    {
+        throw std::runtime_error(fmt::format("Failed to resume SDL audio stream: {}", SDL_GetError()));
+    }
+
+    // SDL doesn't guarantee a fixed-size output buffer, nor does it provide any kind of high-water estimate.
+    // In my testing (Windows), it wants samples 3840 per request, at least with our current format (48000 Hz stereo).
+    // We'll dynamically resize these intermediary buffers if needed, but that risks a runtime hitch.
+    // So, start with a size of 5000, so that we hopefully never need to.
+    SDLBufferState->OutputSamplesLeft.resize(5000);
+    SDLBufferState->OutputSamplesRight.resize(5000);
+}
+
+
+SDLRealTimeThread::~SDLRealTimeThread()
+{
+    SDL_DestroyAudioStream(SDLStream);
+    SDLStream = nullptr;
+}
+
+
+void SDLRealTimeThread::OnAudioRequested(void* UserData, SDL_AudioStream*, int AdditionalAmount, int)
+{
+    assert(UserData != nullptr);
+    
+    SDLRealTimeThread& Thread = *static_cast<SDLRealTimeThread*>(UserData);
+
+    // SDL will emit this callback whenever the output buffer needs filling, *or* is finalized for playback.
+    // We're only interested if audio is needed, represented by the "additional amount" of samples required.
+    if (AdditionalAmount > 0)
+    {
+        FramePointers Frame;
+        Frame.SampleCount = AdditionalAmount;
+        Thread.AdvanceFrames(Frame);
+    }
+}
+
+
+void SDLRealTimeThread::BeginFrame(FramePointers& Frame)
+{
+    assert(BufferState != nullptr);
+
+    SDLThreadShared& SDLBufferState = static_cast<SDLThreadShared &>(*BufferState);
+
+    // SDL doesn't guarantee a fixed-size output buffer. We might need to resize our intermediary buffers.
+    // They'll then maintain the previous high-water mark. A resize should happen very infrequently, if ever.
+    if (static_cast<ptrdiff_t>(SDLBufferState.OutputSamplesLeft.size()) < Frame.SampleCount)
+    {
+        SDLBufferState.OutputSamplesLeft.resize(Frame.SampleCount);
+    }
+    if (static_cast<ptrdiff_t>(SDLBufferState.OutputSamplesRight.size()) < Frame.SampleCount)
+    {
+        SDLBufferState.OutputSamplesRight.resize(Frame.SampleCount);
+    }
+
+    // Assign intermediary buffers to receive generated samples.
+    Frame.OutLeft = SDLBufferState.OutputSamplesLeft.data();
+    Frame.OutRight = SDLBufferState.OutputSamplesRight.data();
+}
+
+
+void SDLRealTimeThread::EndFrame(FramePointers& Frame)
+{
+    TRACEABLE_SCOPE;
+
+    assert(BufferState != nullptr);
+    assert(SDLStream != nullptr);
+
+    SDLThreadShared& SDLBufferState = static_cast<SDLThreadShared &>(*BufferState);
+
+    // SDL requires interleaved channels, but can do the interleaving for us. This will, necessarily, perform copies.
+    // If this isn't fast enough, `SDL_PutAudioStreamDataNoCopy()` can read directly from an already-interleaved buffer,
+    // but that means we'd have 1. do our own faster-than-SDL interleave, or 2. generate samples pre-interleaved.
+    const float* SamplesLeft = SDLBufferState.OutputSamplesLeft.data();
+    const float* SamplesRight = SDLBufferState.OutputSamplesLeft.data();
+    const void* Channels[] = { SamplesLeft, SamplesRight };
+
+    if(!SDL_PutAudioStreamPlanarData(SDLStream, Channels, 2, Frame.SampleCount))
+    {
+        throw std::runtime_error(fmt::format("Failed to put SDL Audio stream data: {}", SDL_GetError()));
+    }
+}
+
+
+SDLStream::SDLStream(int SampleRate) :
+    BufferState(),
+    RealTimeThread(&BufferState, SampleRate)
+{ }
+
+
+float SDLStream::GetTemporalPressure()
+{
+    TRACEABLE_SCOPE;
+    return BufferState.TemporalPressure.load();
+}
+
+
+void SDLStream::ProgramChange(ScratchUniquePtr&& NewProgram)
+{
+    TRACEABLE_SCOPE;
+    TRACEABLE_LOCK_GUARD(BufferState.Mutex);
+    BufferState.PendingProgram = std::move(NewProgram);
+}
+
+#endif

--- a/src/sdl_stream.h
+++ b/src/sdl_stream.h
@@ -1,0 +1,58 @@
+// Copyright 2025 Aeva Palecek
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef AUDIO_SDL
+
+#include "audio_backend.h"
+
+struct SDL_AudioStream;
+
+
+struct SDLThreadShared final : AudioThreadShared
+{
+    std::vector<float> OutputSamplesLeft;
+    std::vector<float> OutputSamplesRight;
+};
+
+
+class SDLRealTimeThread final : public RealTimeAudioThread
+{
+    SDL_AudioStream* SDLStream;
+
+    static void OnAudioRequested(void* UserData, SDL_AudioStream* Stream, int AdditionalAmount, int TotalAmount);
+
+public:
+    SDLRealTimeThread(SDLThreadShared* WasapiBufferState, int SampleRate);
+    virtual ~SDLRealTimeThread() override;
+
+    virtual void BeginFrame(FramePointers& Frame) override;
+    virtual void EndFrame(FramePointers& Frame) override;
+};
+
+
+class SDLStream final : public AudioStream
+{
+    SDLThreadShared BufferState;
+    SDLRealTimeThread RealTimeThread;
+
+public:
+    SDLStream(int SampleRate);
+
+    virtual float GetTemporalPressure() override;
+    virtual void ProgramChange(ScratchUniquePtr&& NewProgram) override;
+};
+
+#endif


### PR DESCRIPTION
Thanks to the fine work of the SDL team, this is by far the simplest backend. There's *almost* no "extra work" required on our part: we open a stream, wait for a callback to request more audio, then directly pass in our samples.

The quirks are:
- SDL's handy one-and-done helper for a simple single-object audio stream, which currently fits our use case perfectly, returns a "paused" stream, which must be manually resumed. This is apparently solely for SDL2 API compatibility.
- SDL can't provide a guaranteed fixed-size output buffer; samples required may vary. So we need our intermediary buffers to be able to resize themselves to whatever the next high-water mark is. This is not expected to happen frequently, if at all -- on my machine, it's an exact 3840 samples every time -- so I provide a best-guess starting capacity of 5000 to hopefully ward off any actual need to resize.
- SDL requires interleaved data, but our data is separated per-channel. SDL can, helpfully, do the interleaving for us, which is handy; but this might be slower than its fastest API option of directly reading from an already-interleaved buffer. This might signal a future optimization of pre-interleaving generated samples, so neither SDL nor our backend needs to perform this step. (WASAPI also requires interleaved, which we perform manually, FWIW.)

Since this is now the most-compatible backend (we vendor SDL, and it supports tons of platforms), I've listed it first in the build options, to signal it's the "use this if you don't have a better idea" case. This does of course mean it depends on our SDL target, which required reorganizing the build file slightly.