### PR TITLE
Mollybuild CLI update

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -10,7 +10,7 @@ self-contained executable (via [Pyinstaller](https://pyinstaller.org/en/stable/)
 As much of this as possible is automated using `mollybuild.py`, a project-
 specific build script. End-users Shouldn't™ have to care about anything more
 than:
-- `python mollybuild.py build` - Build an iterative development environment.
+- `python mollybuild.py develop` - Build an iterative development environment.
 - `python -m mollytime` - Run from the development environment, auto-recompiling if needed.
 - `python mollybuild.py package` - Package the project into source distribution, wheel, and self-contained executable.
 
@@ -23,7 +23,7 @@ Building a development environment for the project requires:
 - `pip install meson-python` - [Meson backend for building Python wheels.](https://mesonbuild.com/meson-python/)
 - `pip install ninja` - [C++ backend used by Meson.](https://ninja-build.org/)
 
-`mollybuild.py build` acquires all of these automatically.
+`mollybuild.py develop` and `mollybuild.py package` acquire all of these automatically.
 
 Packaging the project requires:
 - `pip install build` - [Top-level Python packaging tool.](https://pypi.org/project/build/)
@@ -105,7 +105,7 @@ covered here, like whether or not to emit optimized builds.
 
 > IMPORTANT: On Linux, you'll need to disable Meson's `b_asneeded` and `b_lundef` options.
 
-`mollybuild.py build` handles all of this automatically.
+`mollybuild.py develop` handles all of this automatically.
 
 ## 4. Running the project
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ please let me know and I'll write them down here.
 ## "I want to work on / quickly try out the project!"
 
 Run this:
-- `python mollybuild.py develop <mode> <toolchain>`
+- `python mollybuild.py develop -m <mode> -t <toolchain>`
 
 You can see supported `<mode>`s and `<toolchain>`s by checking command help:
 - `python mollybuild.py develop -h`
@@ -50,7 +50,7 @@ source files since the last run.
 ## "I want to package the project!"
 
 Run this:
-- `python mollybuild.py package <toolchain>`
+- `python mollybuild.py package -t <toolchain>`
 
 You can see supported `<toolchain>`s by checking command help:
 - `python mollybuild.py package -h`
@@ -62,4 +62,11 @@ using [Pyinstaller](https://pyinstaller.org/).
 
 ## "I need to do things to the build system..."
 
-With sincere condolences, consult `BUILD.md` for more details.
+If you just need to configure Meson options -- whether built-in options like the `cpp`
+compiler, or Mollytime-specific options like which audio drivers to include -- you can
+pass these to `mollybuild.py` as extra positional arguments, in the form `option=value`.
+
+E.g.:
+- `python mollybuild.py develop -m debug cpp=g++ audio_driver_jack=disabled`
+
+For anything further, consult `BUILD.md` for more details, with sincere condolences.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ please let me know and I'll write them down here.
 ## "I want to work on / quickly try out the project!"
 
 Run this:
-- `python mollybuild.py build <mode> <toolchain>`
+- `python mollybuild.py develop <mode> <toolchain>`
 
 You can see supported `<mode>`s and `<toolchain>`s by checking command help:
-- `python mollybuild.py build -h`
+- `python mollybuild.py develop -h`
 
 That's it! Now just run `python -m mollytime` to launch the project. When you do,
 the C++ extension module will be automatically recompiled if you've changed any

--- a/meson.build
+++ b/meson.build
@@ -6,8 +6,6 @@ project('mollytime', 'cpp',
     ]
 )
 
-cmake = import('cmake')
-fs = import('fs')
 py = import('python')
 
 compiler = meson.get_compiler('cpp')

--- a/mollybuild.py
+++ b/mollybuild.py
@@ -108,6 +108,11 @@ def develop(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace
             toolchain_arg = f"--native-file={toolchain_file.resolve()}"
             install_args += [ f"-Csetup-args={toolchain_arg}" ]
             install_args += _HACK_extract_override_overrides(toolchain_file)
+    
+    # Apply Meson options.
+    meson_options: list[str] = args_dict.get("meson_options", [])  # pyright: ignore[reportAny]
+    for option in meson_options:
+        install_args += [f"-Csetup-args=-D{option}"]
 
     # Go.
     install_args += [ "-v", "--editable", "." ]
@@ -149,6 +154,11 @@ def package(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace
         if toolchain_file != None:
             toolchain_arg = f"--native-file={toolchain_file.resolve()}"
             setup_args += [ f"-Csetup-args={toolchain_arg}" ]
+    
+    # Apply Meson options.
+    meson_options: list[str] = args_dict.get("meson_options", [])  # pyright: ignore[reportAny]
+    for option in meson_options:
+        setup_args += [f"-Csetup-args=-D{option}"]
     
     # Build the source distribution & wheel.
     package_result = subprocess.run(setup_args, stdout = PIPE)
@@ -261,26 +271,36 @@ if __name__ == "__main__":
     develop_parser = subparsers.add_parser("develop", help = "Build a working environment. Once complete, you can just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run.")
     develop_parser.set_defaults(command = develop)
     _ = develop_parser.add_argument(
-        "mode",
+        "--mode", "-m",
         help = "Build mode. If unspecified, uses `debug`.",
         choices = modes.keys(),
-        nargs = "?"
+        required = False
     )
     _ = develop_parser.add_argument(
-        "toolchain",
+        "--toolchain", "-t",
         help = "Toolchain to build with. If unspecified, uses `win32-msvc` on Windows, `linux-gcc` on Linux, and Meson's best guess on other platforms.",
         choices = toolchains.keys(),
-        nargs = "?"
+        required = False
+    )
+    _ = develop_parser.add_argument(
+        "meson_options",
+        help = "Option overrides to pass to Meson, in the form `option=value`.",
+        nargs = "*"
     )
 
     # `package` command
     package_parser = subparsers.add_parser("package", help = "Build a distributable Python package (sdist and wheel), and Pyinstaller executable.")
     package_parser.set_defaults(command = package)
     _ = package_parser.add_argument(
-        "toolchain",
+        "--toolchain", "-t",
         help = "Toolchain to build with. If unspecified, uses `win32-msvc` on Windows, `linux-gcc` on Linux, and Meson's best guess on other platforms.",
         choices = toolchains.keys(),
-        nargs = "?"
+        required = False
+    )
+    _ = package_parser.add_argument(
+        "meson_options",
+        help = "Option overrides to pass to Meson, in the form `option=value`.",
+        nargs = "*"
     )
 
     # Go

--- a/mollybuild.py
+++ b/mollybuild.py
@@ -14,12 +14,35 @@ from argparse import ArgumentParser, Namespace
 from configparser import ConfigParser
 from pathlib import Path
 from subprocess import PIPE
+from typing import Any
 from zipfile import ZipFile
 
 def _get_dependencies(dependencies: list[str]):
     pip_args = [ sys.executable, "-m", "pip", "install" ] + dependencies
     pip_result = subprocess.run(pip_args)
     pip_result.check_returncode()
+
+def _get_mode_name(args_dict: dict[str, Any]):  # pyright: ignore[reportExplicitAny]
+    mode_name: str | None = args_dict.get("mode", None)
+    return mode_name if mode_name != None else "debug"
+
+def _get_toolchain_name(args_dict: dict[str, Any]):  # pyright: ignore[reportExplicitAny]
+    default_toolchain: str | None
+    match sys.platform:
+        case "win32":
+            default_toolchain = "win32-msvc"
+        case "linux":
+            default_toolchain = "linux-gcc"
+        case _:
+            default_toolchain = None
+            print(
+                f"WARNING: Mollytime doesn't officially support your platform, '{sys.platform}'."
+                + "\nMeson will try to find a working C++ toolchain, but it might fail.",
+                file = sys.stderr
+            )
+
+    toolchain_name: str | None = args_dict.get("toolchain", None)
+    return toolchain_name if toolchain_name != None else default_toolchain
 
 # HACK: UGH: So, meson-python "helpfully" overrides some built-in Meson options:
 # - `buildtype  = release`
@@ -70,16 +93,15 @@ def develop(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace
     install_args += [ "-Ceditable-verbose=true" ]
     
     # Gather mode config, if specified.
-    mode_name: str | None = args_dict.get("mode", None)
-    if mode_name != None:
-        mode_file = modes.get(mode_name, None)
-        if mode_file != None:
-            mode_arg = f"--native-file={mode_file.resolve()}"
-            install_args += [ f"-Csetup-args={mode_arg}" ]
-            install_args += _HACK_extract_override_overrides(mode_file)
-    
+    mode_name = _get_mode_name(args_dict)
+    mode_file = modes.get(mode_name, None)
+    if mode_file != None:
+        mode_arg = f"--native-file={mode_file.resolve()}"
+        install_args += [ f"-Csetup-args={mode_arg}" ]
+        install_args += _HACK_extract_override_overrides(mode_file)
+
     # Gather toolchain config, if specified.
-    toolchain_name: str | None = args_dict.get("toolchain", None)
+    toolchain_name = _get_toolchain_name(args_dict)
     if toolchain_name != None:
         toolchain_file = toolchains.get(toolchain_name, None)
         if toolchain_file != None:
@@ -121,7 +143,7 @@ def package(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace
     setup_args += [ f"-Csetup-args={mode_arg}" ]
     
     # Gather toolchain config, if specified.
-    toolchain_name: str | None = args_dict.get("toolchain", None)
+    toolchain_name = _get_toolchain_name(args_dict)
     if toolchain_name != None:
         toolchain_file = toolchains.get(toolchain_name, None)
         if toolchain_file != None:
@@ -241,12 +263,14 @@ if __name__ == "__main__":
     _ = develop_parser.add_argument(
         "mode",
         help = "Build mode. If unspecified, uses `debug`.",
-        choices = modes.keys()
+        choices = modes.keys(),
+        nargs = "?"
     )
     _ = develop_parser.add_argument(
         "toolchain",
-        help = "Toolchain to build with. If unspecified, uses your system default, which might not be in this list.",
-        choices = toolchains.keys()
+        help = "Toolchain to build with. If unspecified, uses `win32-msvc` on Windows, `linux-gcc` on Linux, and Meson's best guess on other platforms.",
+        choices = toolchains.keys(),
+        nargs = "?"
     )
 
     # `package` command
@@ -254,8 +278,9 @@ if __name__ == "__main__":
     package_parser.set_defaults(command = package)
     _ = package_parser.add_argument(
         "toolchain",
-        help = "Toolchain to build with. If unspecified, uses your system default.",
-        choices = toolchains.keys()
+        help = "Toolchain to build with. If unspecified, uses `win32-msvc` on Windows, `linux-gcc` on Linux, and Meson's best guess on other platforms.",
+        choices = toolchains.keys(),
+        nargs = "?"
     )
 
     # Go

--- a/mollybuild.py
+++ b/mollybuild.py
@@ -55,25 +55,6 @@ def _HACK_extract_override_overrides(native_file: Path) -> list[str]:
     
     return args
 
-def clean(_modes: dict[str, Path], _toolchains: dict[str, Path], _args: Namespace):
-    build_dir = Path("build")
-    dist_dir = Path("dist")
-    third_party_dir = Path("third_party")
-
-    shutil.rmtree(build_dir, True)
-    shutil.rmtree(dist_dir, True)
-
-    for submodule_dir in third_party_dir.iterdir():
-        # HACK
-        if submodule_dir.name == "VAStateVariableFilter":
-            continue
-        
-        for everything in submodule_dir.iterdir():
-            if everything.is_dir():
-                shutil.rmtree(everything, True)
-            else:
-                os.remove(everything)
-
 def build(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
     # Grab dependencies.
     _get_dependencies([ "meson", "meson-python", "ninja" ])
@@ -253,10 +234,6 @@ if __name__ == "__main__":
         argument_default = "-h"
     )
     subparsers = parser.add_subparsers(title = "Commands")
-
-    # `clean` command
-    clean_parser = subparsers.add_parser("clean")
-    clean_parser.set_defaults(command = clean)
 
     # `build` command
     build_parser = subparsers.add_parser("build", help = "Development: Build a working environment. Once complete, you can just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run.")

--- a/mollybuild.py
+++ b/mollybuild.py
@@ -55,7 +55,7 @@ def _HACK_extract_override_overrides(native_file: Path) -> list[str]:
     
     return args
 
-def build(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
+def develop(modes: dict[str, Path], toolchains: dict[str, Path], args: Namespace):
     # Grab dependencies.
     _get_dependencies([ "meson", "meson-python", "ninja" ])
 
@@ -229,28 +229,28 @@ if __name__ == "__main__":
         prog = "mollybuild",
         description = \
             "Concise build helper." +
-            "\nRun `init` after cloning the project. Then, for an iterative 'development' workflow, first run `build`, then just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run." +
-            "\nWhen you're ready to distribute, run `package` to build a wheel, or `exe` to build a Pyinstaller distribution.",
+            "\nFor an iterative development workflow, first run `develop`. Then, just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run." +
+            "\nWhen you're ready to distribute, run `package` to build a wheel and Pyinstaller distribution.",
         argument_default = "-h"
     )
     subparsers = parser.add_subparsers(title = "Commands")
 
-    # `build` command
-    build_parser = subparsers.add_parser("build", help = "Development: Build a working environment. Once complete, you can just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run.")
-    build_parser.set_defaults(command = build)
-    _ = build_parser.add_argument(
+    # `develop` command
+    develop_parser = subparsers.add_parser("develop", help = "Build a working environment. Once complete, you can just run the project with `python -m mollytime`. C++ changes will be automatically recompiled when you run.")
+    develop_parser.set_defaults(command = develop)
+    _ = develop_parser.add_argument(
         "mode",
         help = "Build mode. If unspecified, uses `debug`.",
         choices = modes.keys()
     )
-    _ = build_parser.add_argument(
+    _ = develop_parser.add_argument(
         "toolchain",
         help = "Toolchain to build with. If unspecified, uses your system default, which might not be in this list.",
         choices = toolchains.keys()
     )
 
     # `package` command
-    package_parser = subparsers.add_parser("package", help = "Release: Build a distributable Python package (sdist and wheel).")
+    package_parser = subparsers.add_parser("package", help = "Build a distributable Python package (sdist and wheel), and Pyinstaller executable.")
     package_parser.set_defaults(command = package)
     _ = package_parser.add_argument(
         "toolchain",


### PR DESCRIPTION
1. `mollybuild.py build` -> `mollybuild.py develop`. When this was first named -- long before integrating `meson-python` and its support for editable-install packages -- it was doing little more than wrapping `meson build`. Now, this has become a complete misnomer: it's doing a lot more than building, and it's no longer a prerequisite for packaging. While I was here, I took the opportunity to clean up misleading / obsolete doc strings.

2. The command line now supports specification of Meson options (built-in or project-specific), as extra positional arguments. Now you don't have to edit config files to locally turn stuff on and off. Options are provided in the form `option=value`, which are then passed more-or-less directly to Meson. To disambiguate the mode & toolchain arguments, they're now provided using named arguments: `--mode / -m`, and `--toolchain / -t`. The README has been updated accordingly.

3. Mode & toolchain arguments may now be omitted. If mode is emitted, `debug` mode will be used. If toolchain is omitted, `win32-msvc` will be used on Windows, `linux-gcc` will be used on Linux,, and nothing will be specified on unsupported platforms, giving Meson the opportunity to figure something out (at the user's own risk, as warned by `mollybuild`.) Reminder: the `package` command doesn't take a `mode` argument either way, always forcing Release.

Examples:
- `python mollybuild.py develop` - New: Most minimal command. Supplies documented defaults for mode and toolchain. Meson options use default values.
- `python mollybuild.py develop -m debug -t linux-clang` - Equivalent to previous behavior. Mode & toolchain are explicated; only defined modes and toolchains (in `build_native/`) are valid. Meson options use default values.
- `python mollybuild.py develop -m debug -t linux-clang audio_driver_jack=disabled asan=enabled` - New: Along with explicit mode & toolchain, some Meson options are specified.