### PR TITLE
Build maintenance for GCC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,18 +53,6 @@ elif compiler.get_argument_syntax() == 'msvc'
     )
 endif
 
-# Force libc++ when compiling on Linux
-if compiler.get_id() == 'clang'
-    # NOTE: according to https://mesonbuild.com/Reference-tables.html#compiler-ids,
-    # compiler.get_id() probably returns "clang-cl" for Windows clang, so branching again
-    # on the build machine target is probably not necessary, but this (hopefully) avoids
-    # regressing the Windows build until it can be tested properly.
-    if build_machine.system() != 'windows'
-        add_project_arguments(['-stdlib=libc++'], language : 'cpp')
-        add_project_link_arguments(['-stdlib=libc++'], language : 'cpp')
-    endif
-endif
-
 # ---
 # Source files
 

--- a/mollytime/backend/audio_driver.cpp
+++ b/mollytime/backend/audio_driver.cpp
@@ -33,6 +33,9 @@
 #include <memory>
 
 
+using Clock = std::chrono::steady_clock;
+using TimePoint = std::chrono::time_point<Clock>;
+
 
 static std::unique_ptr<AudioStream> Stream;
 

--- a/mollytime/backend/audio_driver.h
+++ b/mollytime/backend/audio_driver.h
@@ -32,10 +32,6 @@
 #pragma clang diagnostic pop
 
 
-using Clock = std::chrono::steady_clock;
-using TimePoint = std::chrono::time_point<Clock>;
-
-
 struct AudioThreadShared
 {
     DECLARE_TRACEABLE_MUTEX(Mutex);

--- a/mollytime/backend/glm_common.h
+++ b/mollytime/backend/glm_common.h
@@ -29,6 +29,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #pragma warning(push)
 #pragma warning(disable : 4201 4464)
 #include <glm/vec3.hpp>
@@ -39,6 +41,7 @@
 #include <glm/gtx/extended_min_max.hpp>
 #include <glm/gtx/quaternion.hpp>
 #pragma warning(pop)
+#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
 
 

--- a/mollytime/backend/py_api.cpp
+++ b/mollytime/backend/py_api.cpp
@@ -23,12 +23,15 @@
 #pragma clang diagnostic ignored "-Wlanguage-extension-token"
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 #pragma warning(push)
 #pragma warning(disable : 4191 4355 4371 4464 4686 4868 5039)
 #include <pybind11/pybind11.h>
 #include <pybind11/native_enum.h>
 #include <pybind11/stl.h>
 #pragma warning(pop)
+#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
 
 #include "colors.h"

--- a/mollytime/backend/py_api.cpp
+++ b/mollytime/backend/py_api.cpp
@@ -114,7 +114,14 @@ static ColorPoint MakeHSL(float H, float S, float L)
 }
 
 
-PYBIND11_MODULE(backend, m) {
+// HACK: Suppress an otherwise-unsuppressable GCC `-pedantic `warning by passing an (unused) value
+// to PYBIND11_MODULE's variadic macro parameter. (If this isn't one of pybind11's defined
+// options, it won't alter program beahvior.)
+//
+// The warning is: "ISO C++11 requires at least one argument for the "..." in a variadic macro"
+// This is nonetheless supported in every C and C++ compiler since forever. Clang and MSVC allow
+// us to suppress this with individual pragmas, but GCC doesn't.
+PYBIND11_MODULE(backend, m, 0) {
 	m.doc() = "mollytime c++ internals";
 
 	py::native_enum<ColorSpace>(m, "ColorSpace", "enum.Enum")

--- a/mollytime/backend/sdl.h
+++ b/mollytime/backend/sdl.h
@@ -33,7 +33,7 @@ struct Rect
     Rect(const Point& Position, const Size& InSize);
     
     Size GetSize() const;
-    void SetSize(const Size& Size);
+    void SetSize(const Size& InSize);
     
     float GetLeft() const;
     void SetLeft(float Left);

--- a/mollytime/backend/sdl.h
+++ b/mollytime/backend/sdl.h
@@ -29,8 +29,8 @@ struct Rect
     float Width;
     float Height;
     
-    Rect(float X, float Y, float Width, float Height);
-    Rect(const Point& Position, const Size& Size);
+    Rect(float InX, float InY, float InWidth, float InHeight);
+    Rect(const Point& Position, const Size& InSize);
     
     Size GetSize() const;
     void SetSize(const Size& Size);
@@ -68,7 +68,7 @@ struct Rect
     Point GetCenter() const;
     void SetCenter(const Point& Center);
     
-    bool ContainsPoint(const Point& Point) const;
+    bool ContainsPoint(const Point& InPoint) const;
     
     std::tuple<Point, Point> IntersectLine(const Point& Start, const Point& End) const;
     
@@ -244,8 +244,8 @@ namespace Draw
         // When passed no arguments, this allows drawing and blitting on the rendering surface.
         Texture();
         Texture(SDL_Surface* Surface);
-        Texture(int Width, int Height);
-        Texture(const Size& Size);
+        Texture(int InWidth, int InHeight);
+        Texture(const Size& InSize);
         
         float GetWidth() const;
         float GetHeight() const;
@@ -315,7 +315,7 @@ class Font
 public:
     static void Init();
     
-    explicit Font(const std::string_view& FilePath, float Size);
+    explicit Font(const std::string_view& FilePath, float InSize);
 
     ~Font();
     

--- a/mollytime/backend/sdl_draw.cpp
+++ b/mollytime/backend/sdl_draw.cpp
@@ -82,9 +82,9 @@ namespace Draw
         SetBlendMode();
     }
 
-    Texture::Texture(int Width, int Height) :
-        Width(Width),
-        Height(Height)
+    Texture::Texture(int InWidth, int InHeight) :
+        Width(InWidth),
+        Height(InHeight)
     {
         assert(Width + Height >= 1);
 

--- a/mollytime/backend/sdl_font.cpp
+++ b/mollytime/backend/sdl_font.cpp
@@ -16,7 +16,7 @@ void Font::Init()
     }
 }
 
-Font::Font(const std::string_view& FilePath, float Size)
+Font::Font(const std::string_view& FilePath, float InSize)
 {
     SDL_IOStream* IO = SDL_IOFromFile(FilePath.data(), "rb");
     if (IO == nullptr)
@@ -24,7 +24,7 @@ Font::Font(const std::string_view& FilePath, float Size)
         throw std::runtime_error(fmt::format("Failed to open font file '{}'. SDL error: {}", FilePath, SDL_GetError()));
     }
 
-    SDLFont = TTF_OpenFontIO(IO, true, Size);
+    SDLFont = TTF_OpenFontIO(IO, true, InSize);
     if(SDLFont == nullptr)
     {
         throw std::runtime_error(fmt::format("Failed to load font file '{}'. SDL error: {}", FilePath, SDL_GetError()));

--- a/mollytime/backend/sdl_rect.cpp
+++ b/mollytime/backend/sdl_rect.cpp
@@ -23,10 +23,10 @@ Size Rect::GetSize() const
     return { Width, Height };
 }
 
-void Rect::SetSize(const Size& Size)
+void Rect::SetSize(const Size& InSize)
 {
-    Width = std::get<0>(Size);
-    Height = std::get<1>(Size);
+    Width = std::get<0>(InSize);
+    Height = std::get<1>(InSize);
 }
 
 float Rect::GetLeft() const

--- a/mollytime/backend/sdl_rect.cpp
+++ b/mollytime/backend/sdl_rect.cpp
@@ -4,18 +4,18 @@
 
 #include <cassert>
 
-Rect::Rect(float X, float Y, float Width, float Height) :
-    X(X),
-    Y(Y),
-    Width(Width),
-    Height(Height)
+Rect::Rect(float InX, float InY, float InWidth, float InHeight) :
+    X(InX),
+    Y(InY),
+    Width(InWidth),
+    Height(InHeight)
 { }
 
-Rect::Rect(const Point& Position, const Size& Size) :
+Rect::Rect(const Point& Position, const Size& InSize) :
     X(std::get<0>(Position)),
     Y(std::get<1>(Position)),
-    Width(std::get<0>(Size)),
-    Height(std::get<1>(Size))
+    Width(std::get<0>(InSize)),
+    Height(std::get<1>(InSize))
 { }
 
 Size Rect::GetSize() const
@@ -146,9 +146,9 @@ void Rect::SetCenter(const Point& Center)
     SetCenterY(CenterY);
 }
 
-bool Rect::ContainsPoint(const Point& Point) const
+bool Rect::ContainsPoint(const Point& InPoint) const
 {
-    const auto [PointX, PointY] = Point;
+    const auto [PointX, PointY] = InPoint;
     const SDL_FPoint SDLPoint { PointX, PointY };
     const SDL_FRect SDLRect { X, Y, Width, Height };
 

--- a/mollytime/backend/thunks.cpp
+++ b/mollytime/backend/thunks.cpp
@@ -1774,7 +1774,7 @@ struct InputSequenceThunk : public InstructionThunk
                 // Modulating the index happens at the start of this thunk, because the patch may
                 // have been modified between calls, which could result in the sequence changing
                 // length.
-                const int Period = static_cast<const int>(Sequence.size());
+                const int Period = static_cast<int>(Sequence.size());
                 int Index = int(Cursor) % Period;
                 OutValue = Sequence[Index][Lane];
 

--- a/mollytime/backend/thunks.h
+++ b/mollytime/backend/thunks.h
@@ -607,10 +607,10 @@ private:
     {
         SetCommon<ThunkT>();
         BasicCreateAndConnect[(int)ThunkT::Info.Symbol] = [](
-            std::vector<double>* RegisterFile, auto& Inputs, auto& Outputs, auto& Closures)
+            std::vector<double>* RegisterFile, auto& InInputs, auto& InOutputs, auto& InClosures)
         {
             auto Thunk = std::make_shared<ThunkT>();
-            Thunk->Registers.Connect(Inputs, Outputs, Closures, RegisterFile);
+            Thunk->Registers.Connect(InInputs, InOutputs, InClosures, RegisterFile);
             Thunk->Reset();
             return std::static_pointer_cast<InstructionThunk>(Thunk);
         };
@@ -621,10 +621,10 @@ private:
     {
         SetCommon<ThunkT>();
         MidiCreateAndConnect[(int)ThunkT::Info.Symbol] = [](
-            std::vector<double>* RegisterFile, struct Scratch* Program, auto& Inputs, auto& Outputs, auto& Closures)
+            std::vector<double>* RegisterFile, struct Scratch* Program, auto& InInputs, auto& InOutputs, auto& InClosures)
         {
             auto Thunk = std::make_shared<ThunkT>();
-            Thunk->Registers.Connect(Inputs, Outputs, Closures, RegisterFile);
+            Thunk->Registers.Connect(InInputs, InOutputs, InClosures, RegisterFile);
             Thunk->Reset();
             Thunk->Program = Program;
             return std::static_pointer_cast<InstructionThunk>(Thunk);
@@ -636,12 +636,12 @@ private:
     {
         SetCommon<ThunkT>();
         WidgetCreateAndConnect[(int)ThunkT::Info.Symbol] = [](
-            std::vector<double>* RegisterFile, auto& Inputs, auto& Outputs, auto& Closures, auto& SpecialInput)
+            std::vector<double>* RegisterFile, auto& InInputs, auto& InOutputs, auto& InClosures, auto& InSpecialInput)
         {
             auto Thunk = std::make_shared<ThunkT>();
-            Thunk->Registers.Connect(Inputs, Outputs, Closures, RegisterFile);
+            Thunk->Registers.Connect(InInputs, InOutputs, InClosures, RegisterFile);
             Thunk->Reset();
-            Thunk->Input = SpecialInput;
+            Thunk->Input = InSpecialInput;
             return std::static_pointer_cast<InstructionThunk>(Thunk);
         };
     }
@@ -651,10 +651,10 @@ private:
     {
         SetCommon<ThunkT>();
         TapeCreateAndConnect[(int)ThunkT::Info.Symbol] = [](
-            std::vector<double>* RegisterFile, std::vector<MagicTapeUniquePtr>* TapeFile, std::ptrdiff_t TapeIndex, auto& Inputs, auto& Outputs, auto& Closures)
+            std::vector<double>* RegisterFile, std::vector<MagicTapeUniquePtr>* TapeFile, std::ptrdiff_t TapeIndex, auto& InInputs, auto& InOutputs, auto& InClosures)
         {
             auto Thunk = std::make_shared<ThunkT>();
-            Thunk->Registers.Connect(Inputs, Outputs, Closures, RegisterFile);
+            Thunk->Registers.Connect(InInputs, InOutputs, InClosures, RegisterFile);
             Thunk->Reset();
             Thunk->TapeFile = TapeFile;
             Thunk->TapeIndex = TapeIndex;


### PR DESCRIPTION
GCC emits a few extra warnings that Clang doesn't, especially regarding variable shadowing. Clang is stricter about only warning on constructs that are actually semantically ambiguous, while GCC is a bit more heuristics-ish. GCC also doesn't properly split many `-pedantic` warnings into individual options, nor allow them to be disabled via pragma, requiring a small HACK in `py_api.cpp`.

Lastly, the hardcoded toggle for LLVM's C++ stdlib has been removed, at Aeva's request, as it only mostly works on Linux, and doesn't work at all on Windows. It can be reconsidered as a formal build option once more research into its viability & requirements has been done.