### PR TITLE
Specify minimum versions for all third-party dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -135,13 +135,13 @@ libm = compiler.find_library('m', required : false)
 libdl = compiler.find_library('dl', required : false)
 
 # From wrap
-boost = dependency('boost', required : true, default_options : 'modules=atomic,stacktrace')
-fmt = dependency('fmt', required : true, default_options : 'header-only=true')
-glm = dependency('glm', required : true)
-pybind11 = dependency('pybind11', required : true)
-sdl3 = dependency('sdl3', required : true, default_options : { 'warning_level' : '0' })
-sdl3_ttf = dependency('sdl3_ttf', required : true, default_options : { 'warning_level' : '0' })
-tracy = dependency('tracy', required : get_option('tracy'))
+boost = dependency('boost', required : true, version : '>=1.90.0', default_options : 'modules=atomic,stacktrace')
+fmt = dependency('fmt', required : true, version : '>=12.0.0', default_options : 'header-only=true')
+glm = dependency('glm', required : true, version : '>=1.0.1')
+pybind11 = dependency('pybind11', required : true, version : '>=3.0.0')
+sdl3 = dependency('sdl3', required : true, version : '>=3.4.0', default_options : { 'warning_level' : '0' })
+sdl3_ttf = dependency('sdl3_ttf', required : true, version : '>=3.2.0', default_options : { 'warning_level' : '0' })
+tracy = dependency('tracy', version : '>=0.13.0', required : get_option('tracy'))
 
 # ---
 # Targets


### PR DESCRIPTION
SDL3, pybind11, and (probably) GLM are actually accurate to the required minimum version. The rest use the version we've been using so far via the most recent wrap download. These, thus, might be downgradable if there's a strong need to prove viability on older versions, and said viability is subsequently proven.