### PR TITLE
Add support for (one-time, on-startup) runtime selection of audio drivers

### DIFF
--- a/mollytime/__main__.py
+++ b/mollytime/__main__.py
@@ -27,6 +27,28 @@ from .patterns import *
 from .screens.common import program_card
 from .screens.inspect import inspect_screen
 
+def _select_audio_driver(driver_name, sample_rate):
+    driver_types = (backend.SDLStream, backend.JackStream, backend.WasapiStream, backend.StubStream)
+    driver_name = driver_name.casefold()
+    driver_type = None
+
+    for type in driver_types:
+        if type.get_name().casefold() == driver_name:
+            driver_type = type
+            break
+    
+    if driver_type is not None and driver_type.is_available():
+        return driver_type(sample_rate)
+    
+    fallback_type = backend.SDLStream if backend.SDLStream.is_available() else backend.StubStream
+    fallback_reason = "not valid" if driver_type is None else "not available"
+    print(f"Audio driver \"{driver_name}\" is {fallback_reason}.  Falling back to {fallback_type.get_name()}.")
+    print("The following are the audio drivers available on this system:")
+    for type in driver_types:
+        if type.is_available():
+            print(f"- {type.get_name()}")
+    
+    return fallback_type(sample_rate)
 
 def main():
     operating_system = platform.system()
@@ -40,6 +62,7 @@ def main():
     force_fullscreen = 0
     dump_icon = False
     vertical_inches = None
+    audio_driver_name = "SDL" if backend.SDLStream.is_available() else "Stub"
 
     while args:
         arg = args.pop(0)
@@ -53,6 +76,8 @@ def main():
             vertical_inches = float(args.pop(0))
         elif arg == "-p":
             backend.set_default_polyphony(int(args.pop(0)))
+        elif arg in ("-a" "--audio-driver"):
+            audio_driver_name = args.pop(0)
         else:
             print(f"Ignoring unknown arg: {arg}")
 
@@ -62,7 +87,10 @@ def main():
     #print(f"read only mode: {backend.get_read_only_mode()}")
 
     backend.init_midi()
-    backend.init_audio(48000)
+
+    audio_driver = _select_audio_driver(audio_driver_name, 48000)
+    print(f"Audio driver: {audio_driver.get_name()}")
+    backend.init_audio(audio_driver)
 
     backend.display.init(force_fullscreen)
     backend.draw.init()

--- a/mollytime/__main__.py
+++ b/mollytime/__main__.py
@@ -28,27 +28,43 @@ from .screens.common import program_card
 from .screens.inspect import inspect_screen
 
 def _select_audio_driver(driver_name, sample_rate):
-    driver_types = (backend.SDLStream, backend.JackStream, backend.WasapiStream, backend.StubStream)
-    driver_name = driver_name.casefold()
-    driver_type = None
+    assert backend.StubStream.is_available()
 
+    # Determine the default driver for this platform & build.
+    if platform.system() == "Linux" and backend.JackStream.is_available():
+        default_driver_type = backend.JackStream
+    elif platform.system() == "Windows" and backend.WasapiStream.is_available():
+        default_driver_type = backend.WasapiStream
+    elif backend.SDLStream.is_available():
+        default_driver_type = backend.SDLStream
+    else:
+        default_driver_type = backend.StubStream
+    
+    # If no driver was requested, we can just use the default.
+    if driver_name is None:
+        return default_driver_type(sample_rate)
+    
+    # Find the driver that matches the requested name.
+    driver_types = (backend.SDLStream, backend.JackStream, backend.WasapiStream, backend.StubStream)
+    driver_type = None
     for type in driver_types:
-        if type.get_name().casefold() == driver_name:
+        if type.get_name().casefold() == driver_name.casefold():
             driver_type = type
             break
     
+    # If we got a match, great! Use that.
     if driver_type is not None and driver_type.is_available():
         return driver_type(sample_rate)
     
-    fallback_type = backend.SDLStream if backend.SDLStream.is_available() else backend.StubStream
+    # We didn't get a match. Inform the user of their wrongness, and use the default driver.
     fallback_reason = "not valid" if driver_type is None else "not available"
-    print(f"Audio driver \"{driver_name}\" is {fallback_reason}.  Falling back to {fallback_type.get_name()}.")
+    print(f"Audio driver \"{driver_name}\" is {fallback_reason}.  Falling back to {default_driver_type.get_name()}.")
     print("The following are the audio drivers available on this system:")
     for type in driver_types:
         if type.is_available():
             print(f"- {type.get_name()}")
     
-    return fallback_type(sample_rate)
+    return default_driver_type(sample_rate)
 
 def main():
     operating_system = platform.system()
@@ -62,7 +78,7 @@ def main():
     force_fullscreen = 0
     dump_icon = False
     vertical_inches = None
-    audio_driver_name = "SDL" if backend.SDLStream.is_available() else "Stub"
+    audio_driver_name = None
 
     while args:
         arg = args.pop(0)

--- a/mollytime/backend/audio_driver.cpp
+++ b/mollytime/backend/audio_driver.cpp
@@ -16,18 +16,6 @@
 #include "audio_driver.h"
 #include "midi.h"
 
-#if defined(ENABLE_JACK)
-#include "jack_stream.h"
-#endif
-
-#if defined(AUDIO_WASAPI)
-#include "wasapi_stream.h"
-#endif
-
-#if defined(AUDIO_SDL)
-#include "sdl_stream.h"
-#endif
-
 #include <fmt/format.h>
 
 #include <memory>
@@ -169,33 +157,16 @@ void RealTimeAudioThread::AdvanceFrames(FramePointers& Frame)
 }
 
 
-// This no-op stub is used if no AudioStream is available.  This is
-// primarily intended to aid in porting Mollytime to new platforms.
-struct StubStream final : AudioStream
-{
-    virtual float GetTemporalPressure() override { return 0.0f; }
-    virtual void ProgramChange(ScratchUniquePtr&& NewProgram) override {}
-};
-
-
 AudioStream* Audio::GetStream()
 {
     return Stream.get();
 }
 
 
-void Audio::Init(int SampleRate)
+void Audio::Init(std::unique_ptr<AudioStream>&& InStream)
 {
-#if defined(ENABLE_JACK)
-    Stream = std::make_unique<JackStream>(SampleRate);
-#elif defined(AUDIO_WASAPI)
-    Stream = std::make_unique<WasapiStream>(SampleRate);
-#elif defined(AUDIO_SDL)
-    Stream = std::make_unique<SDLStream>(SampleRate);
-#else
-    fmt::println("No audio stream implementation is available.");
-    Stream = std::make_unique<StubStream>();
-#endif
+    assert(InStream);
+    Stream = std::move(InStream);
 }
 
 

--- a/mollytime/backend/audio_driver.h
+++ b/mollytime/backend/audio_driver.h
@@ -15,12 +15,7 @@
 
 #pragma once
 
-#include <map>
 #include <vector>
-#include <atomic>
-#include <mutex>
-#include <chrono>
-
 #include "patch.h"
 
 #pragma clang diagnostic push
@@ -96,7 +91,7 @@ namespace Audio
 {
     AudioStream* GetStream();
 
-    void Init(int SampleRate);
+    void Init(std::unique_ptr<AudioStream>&& AudioStream);
     void Shutdown();
     float GetTemporalPressure();
 };

--- a/mollytime/backend/jack_stream.h
+++ b/mollytime/backend/jack_stream.h
@@ -55,6 +55,20 @@ public:
     JackStream(int SampleRate);
     virtual ~JackStream() override;
 
+    static constexpr bool IsAvailable()
+    {
+#if defined(ENABLE_JACK)
+        return true;
+#else
+        return false;
+#endif        
+    }
+
+    static std::string_view GetName()
+    {
+        return "Jack";
+    }
+
     virtual bool ImplementsInput() override
     {
         return true;
@@ -64,7 +78,7 @@ public:
     {
         return true;
     }
-    
+
     virtual float GetTemporalPressure() override;
     virtual void ProgramChange(ScratchUniquePtr&& NewProgram) override;
 };

--- a/mollytime/backend/jack_stream.h
+++ b/mollytime/backend/jack_stream.h
@@ -64,7 +64,7 @@ public:
 #endif        
     }
 
-    static std::string_view GetName()
+    static constexpr std::string_view GetName()
     {
         return "Jack";
     }

--- a/mollytime/backend/py_api.cpp
+++ b/mollytime/backend/py_api.cpp
@@ -37,10 +37,15 @@
 #include "colors.h"
 #include "patch.h"
 #include "audio_driver.h"
-#include "alsa_midi.h"
 #include "perf.h"
 #include "sdl.h"
 #include "config.h"
+
+#include "jack_stream.h"
+#include "sdl_stream.h"
+#include "stub_stream.h"
+#include "wasapi_stream.h"
+
 
 namespace py = pybind11;
 
@@ -113,6 +118,24 @@ static ColorPoint MakeHSL(float H, float S, float L)
 	return ColorPoint(ColorSpace::HSL, glm::vec3(H, S, L));
 }
 
+template<typename T>
+static void BindAudioDriver(py::module_& Module, const std::string_view& ClassName)
+{
+    if constexpr (T::IsAvailable())
+    {
+        py::classh<T, AudioStream>(Module, ClassName.data())
+            .def(py::init<int>())
+            .def_static("is_available", &T::IsAvailable)
+            .def_static("get_name", &T::GetName);
+    }
+    else
+    {
+        class UndefinedPlaceholder { UndefinedPlaceholder(); };
+        py::classh<UndefinedPlaceholder>(Module, ClassName.data())
+            .def_static("is_available", &T::IsAvailable)
+            .def_static("get_name", &T::GetName);
+    }
+}
 
 // HACK: Suppress an otherwise-unsuppressable GCC `-pedantic `warning by passing an (unused) value
 // to PYBIND11_MODULE's variadic macro parameter. (If this isn't one of pybind11's defined
@@ -290,6 +313,12 @@ PYBIND11_MODULE(backend, m, 0) {
 	m.def("get_game_data_folder", &Config::GetGameDataFolder);
 	m.def("get_game_config_folder", &Config::GetGameConfigFolder);
 	m.def("get_read_only_mode", &Config::GetReadOnly);
+
+    py::classh<AudioStream> _AudioStream(m, "AudioStream");
+    BindAudioDriver<SDLStream>(m, "SDLStream");
+    BindAudioDriver<JackStream>(m, "JackStream");
+    BindAudioDriver<WasapiStream>(m, "WasapiStream");
+    BindAudioDriver<StubStream>(m, "StubStream");
 
 	m.def("init_audio", &Audio::Init);
 	m.def("shutdown_audio", &Audio::Shutdown);

--- a/mollytime/backend/sdl_stream.h
+++ b/mollytime/backend/sdl_stream.h
@@ -49,6 +49,20 @@ class SDLStream final : public AudioStream
 public:
     SDLStream(int SampleRate);
 
+    static constexpr bool IsAvailable()
+    {
+#if defined(AUDIO_SDL)
+        return true;
+#else
+        return false;
+#endif        
+    }
+
+    static std::string_view GetName()
+    {
+        return "SDL";
+    }
+
     virtual float GetTemporalPressure() override;
     virtual void ProgramChange(ScratchUniquePtr&& NewProgram) override;
 };

--- a/mollytime/backend/sdl_stream.h
+++ b/mollytime/backend/sdl_stream.h
@@ -58,7 +58,7 @@ public:
 #endif        
     }
 
-    static std::string_view GetName()
+    static constexpr std::string_view GetName()
     {
         return "SDL";
     }

--- a/mollytime/backend/stub_stream.h
+++ b/mollytime/backend/stub_stream.h
@@ -1,0 +1,35 @@
+// Copyright 2025 Aeva Palecek
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "audio_driver.h"
+
+struct StubStream final : AudioStream
+{
+    StubStream(int) { }
+
+    static constexpr bool IsAvailable()
+    {
+        return true;
+    }
+
+    static std::string_view GetName()
+    {
+        return "Stub";
+    }
+
+    virtual float GetTemporalPressure() override { return 0.0f; }
+    virtual void ProgramChange(ScratchUniquePtr&& NewProgram) override {}
+};

--- a/mollytime/backend/stub_stream.h
+++ b/mollytime/backend/stub_stream.h
@@ -25,7 +25,7 @@ struct StubStream final : AudioStream
         return true;
     }
 
-    static std::string_view GetName()
+    static constexpr std::string_view GetName()
     {
         return "Stub";
     }

--- a/mollytime/backend/wasapi_stream.cpp
+++ b/mollytime/backend/wasapi_stream.cpp
@@ -15,8 +15,25 @@
 
 #include "wasapi_stream.h"
 
-#include <cassert>
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#define NOMINMAX
+#include <Audioclient.h>
+#include <mmdeviceapi.h>
+#define WINRT_LEAN_AND_MEAN
+#define _SILENCE_CLANG_COROUTINE_MESSAGE
+#include <winrt/base.h>
+#undef _SILENCE_CLANG_COROUTINE_MESSAGE
+#undef WINRT_LEAN_AND_MEAN
+#undef NOMINMAX
+#undef VC_EXTRALEAN
+#undef WIN32_LEAN_AND_MEAN
 
+#include <cassert>
+#include <thread>
+
+template<typename T>
+using ComPtr = winrt::com_ptr<T>;
 
 #define CheckHResult winrt::check_hresult
 
@@ -25,6 +42,28 @@
 const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
 const IID IID_IAudioClient = __uuidof(IAudioClient);
 #pragma clang diagnostic pop
+
+
+class WasapiRealTimeThread final : public RealTimeAudioThread
+{
+    ComPtr<IMMDevice> Device;
+    ComPtr<IAudioClient> AudioClient;
+    ComPtr<IAudioRenderClient> RenderClient;
+    ComPtr<IAudioClock> AudioClock;
+    UINT32 BufferSize;
+    HANDLE EventHandle = nullptr;
+
+    std::thread LoopThread;
+    std::atomic<bool> IsRunning;
+    void Loop();
+
+public:
+    WasapiRealTimeThread(WasapiThreadShared* WasapiBufferState, int SampleRate);
+    virtual ~WasapiRealTimeThread() override;
+
+    virtual void BeginFrame(FramePointers& Frame) override;
+    virtual void EndFrame(FramePointers& Frame) override;
+};
 
 
 WasapiRealTimeThread::WasapiRealTimeThread(WasapiThreadShared* WasapiBufferState, int SampleRate)
@@ -175,7 +214,11 @@ void WasapiRealTimeThread::Loop()
 
 WasapiStream::WasapiStream(int SampleRate) :
     BufferState(),
-    RealTimeThread(&BufferState, SampleRate)
+    RealTimeThread(std::make_unique<WasapiRealTimeThread>(&BufferState, SampleRate))
+{ }
+
+
+WasapiStream::~WasapiStream()
 { }
 
 

--- a/mollytime/backend/wasapi_stream.h
+++ b/mollytime/backend/wasapi_stream.h
@@ -45,7 +45,7 @@ public:
 #endif        
     }
 
-    static std::string_view GetName()
+    static constexpr std::string_view GetName()
     {
         return "Wasapi";
     }

--- a/mollytime/backend/wasapi_stream.h
+++ b/mollytime/backend/wasapi_stream.h
@@ -17,26 +17,7 @@
 
 #include "audio_driver.h"
 
-#include <thread>
 #include <vector>
-
-#define WIN32_LEAN_AND_MEAN
-#define VC_EXTRALEAN
-#define NOMINMAX
-#include <Audioclient.h>
-#include <mmdeviceapi.h>
-#define WINRT_LEAN_AND_MEAN
-#define _SILENCE_CLANG_COROUTINE_MESSAGE
-#include <winrt/base.h>
-#undef _SILENCE_CLANG_COROUTINE_MESSAGE
-#undef WINRT_LEAN_AND_MEAN
-#undef NOMINMAX
-#undef VC_EXTRALEAN
-#undef WIN32_LEAN_AND_MEAN
-
-
-template<typename T>
-using ComPtr = winrt::com_ptr<T>;
 
 
 struct WasapiThreadShared final : AudioThreadShared
@@ -46,35 +27,28 @@ struct WasapiThreadShared final : AudioThreadShared
 };
 
 
-class WasapiRealTimeThread final : public RealTimeAudioThread
-{
-    ComPtr<IMMDevice> Device;
-    ComPtr<IAudioClient> AudioClient;
-    ComPtr<IAudioRenderClient> RenderClient;
-    ComPtr<IAudioClock> AudioClock;
-    UINT32 BufferSize;
-    HANDLE EventHandle = nullptr;
-
-    std::thread LoopThread;
-    std::atomic<bool> IsRunning;
-    void Loop();
-
-public:
-    WasapiRealTimeThread(WasapiThreadShared* WasapiBufferState, int SampleRate);
-    virtual ~WasapiRealTimeThread() override;
-
-    virtual void BeginFrame(FramePointers& Frame) override;
-    virtual void EndFrame(FramePointers& Frame) override;
-};
-
-
 class WasapiStream final : public AudioStream
 {
     WasapiThreadShared BufferState;
-    WasapiRealTimeThread RealTimeThread;
+    std::unique_ptr<class WasapiRealTimeThread> RealTimeThread;
 
 public:
     WasapiStream(int SampleRate);
+    ~WasapiStream();
+
+    static constexpr bool IsAvailable()
+    {
+#if defined(AUDIO_WASAPI)
+        return true;
+#else
+        return false;
+#endif        
+    }
+
+    static std::string_view GetName()
+    {
+        return "Wasapi";
+    }
 
     virtual float GetTemporalPressure() override;
     virtual void ProgramChange(ScratchUniquePtr&& NewProgram) override;


### PR DESCRIPTION
The build system has already been upgraded to compile multiple audio drivers into the same build. Now, we can actually make use of this, and allow the user to pick their favorite on startup.

Use CLI argument `-a` / `--audio-driver` with the name of the desired driver, e.g.:
- `mollytime -a SDL`
- `mollytime --audio-driver Jack`

Name matching is caseless, so just make sure the letters are right. If you enter something unknown or unavailable, it'll fall back to Jack, on Linux; Wasapi, on Windows; SDL, if those aren't available; and finally, the assumed-always-available StubStream, if all else fails.

Under the hood, the most minimal approach to this would be to throw in a bunch of macro towers & enum switches into the guts of the audio system, but that Wouldn't Be Very Object-Oriented Of Me. Instead, Idiomatic C++™ would prefer that we shove as much platform-specificity as we can into our platform-specific objects, pushing decisionmaking out of the implementation, and into the API. As it happens, in this case, I agree.

`Audio::Init()` now directly asks for, and takes ownership of, an AudioStream object (via `std::unique_ptr`). It doesn't care which one you pick, or how you get it. This decisionmaking is instead moved all the way up to the "entry point" of `__main__.py`, where we're free to do as much inspection, logging, and selecting as we want, without complicating implementation details. Audio drivers now declare a consistent "static API" that assists with said inspection / logging, including a `constexpr` check for availability.

This, of course, requires routing drivers through the binding API. This isn't as bad as it seems, and mostly comes down to Pybind11 being a little stale for use cases this specific:
- All audio driver headers except WasapiStream are already fully platform-independent.
- WasapiStream moves its Windows implementation details into an opaque `std:unique_ptr`, restoring platform-independence to its header.
  - The cost is limited to one (1) up-front allocation. The WasapiRealTimeThread otherwise operates entirely on its own, remains alive for as long as the driver does, and is never actually dereferenced, avoiding any further overhead.
  - As a bonus, this means anything including the Wasapi header doesn't get polluted by Windows headers. This is actually necessary, as some of those definitions conflict with ours, e.g. `#define CONST` <-> `OpCode::CONST`.
- By default, Pybind11 only allows ownership transfers from C++ -> Python. However, its newer "smart holder" feature can be used to introduce such support, via `py::classh`. This allows us to transfer the requested driver from Python -> C++. (Pybind11 actually recommends this over the default behavior, which is only default for the sake of backwards compatibility.)
-  If a driver is unavailable, we want to avoid binding both its constructor and its destructor. The former is easy (just don't define it), the latter is not: Pybind11 automatically generates a binding. If we didn't need "smart holders," this would be possible by passing a custom deleter. But we do, so the next-simplest option is to define a stub placeholder type w/ a private constructor, routing only the static bindings (via the actual intended driver type).