### PR TITLE
Add support for selecting MIDI driver at runtime

### DIFF
--- a/mollytime/__main__.py
+++ b/mollytime/__main__.py
@@ -27,6 +27,43 @@ from .patterns import *
 from .screens.common import program_card
 from .screens.inspect import inspect_screen
 
+def _select_midi_driver(driver_name):
+    # Determine the default driver for this build.
+    if backend.AlsaMidiDriver.is_available():
+        default_driver_type = backend.AlsaMidiDriver
+    elif backend.MmeApiMidiDriver.is_available():
+        default_driver_type = backend.MmeApiMidiDriver
+    else:
+        default_driver_type = None
+    
+    # If no driver was requested, we can just use the default.
+    if driver_name is None:
+        return default_driver_type() if default_driver_type is not None else None
+    
+    # Find the driver that matches the requested name.
+    driver_types = (backend.AlsaMidiDriver, backend.MmeApiMidiDriver, backend.StubMidiDriver)
+    driver_type = None
+    for type in driver_types:
+        if type.get_name().casefold() == driver_name.casefold():
+            driver_type = type
+            break
+    
+    # If we got a match, great! Use that.
+    if driver_type is not None and driver_type.is_available():
+        return driver_type()
+    
+    # We didn't get a match. Inform the user of their wrongness, and use the default driver.
+    fallback_reason = "not valid" if driver_type is None else "not available"
+    default_name = default_driver_type.get_name() if default_driver_type is not None else "None"
+
+    print(f"MIDI driver \"{driver_name}\" is {fallback_reason}.  Falling back to {default_name}.")
+    print("The following are the MIDI drivers available on this system:")
+    for type in driver_types:
+        if type.is_available():
+            print(f"- {type.get_name()}")
+    
+    return default_driver_type() if default_driver_type is not None else None
+
 def _select_audio_driver(driver_name, sample_rate):
     assert backend.StubStream.is_available()
 
@@ -78,6 +115,7 @@ def main():
     force_fullscreen = 0
     dump_icon = False
     vertical_inches = None
+    midi_driver_name = None
     audio_driver_name = None
 
     while args:
@@ -92,6 +130,8 @@ def main():
             vertical_inches = float(args.pop(0))
         elif arg == "-p":
             backend.set_default_polyphony(int(args.pop(0)))
+        elif arg in ("-m" "--midi-driver"):
+            midi_driver_name = args.pop(0)
         elif arg in ("-a" "--audio-driver"):
             audio_driver_name = args.pop(0)
         else:
@@ -102,7 +142,12 @@ def main():
     #print(f"config folder: {backend.get_game_config_folder()}")
     #print(f"read only mode: {backend.get_read_only_mode()}")
 
-    backend.init_midi()
+    midi_driver = _select_midi_driver(midi_driver_name)
+    if midi_driver is not None:
+        print(f"Midi driver: {midi_driver.get_name()}")
+        backend.init_midi(midi_driver)
+    else:
+        print("No MIDI driver is available.")
 
     audio_driver = _select_audio_driver(audio_driver_name, 48000)
     print(f"Audio driver: {audio_driver.get_name()}")

--- a/mollytime/backend/alsa_midi.h
+++ b/mollytime/backend/alsa_midi.h
@@ -17,6 +17,8 @@
 
 #include "midi.h"
 
+#include <string_view>
+
 struct _snd_seq;    // Forward declares `typedef struct _snd_seq snd_seq_t` from <alsa/seq.h>.
 
 class AlsaMidiDriver final : public MidiDriver

--- a/mollytime/backend/alsa_midi.h
+++ b/mollytime/backend/alsa_midi.h
@@ -30,5 +30,19 @@ public:
     AlsaMidiDriver();
     virtual ~AlsaMidiDriver() override;
 
+    static constexpr bool IsAvailable()
+    {
+#if defined(MIDI_ALSA)
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    static constexpr std::string_view GetName()
+    {
+        return "Alsa";
+    }
+
     void ProcessEvents(MidiHandler* Handler) override;
 };

--- a/mollytime/backend/midi.cpp
+++ b/mollytime/backend/midi.cpp
@@ -15,19 +15,12 @@
 
 #include "midi.h"
 
-#if defined(MIDI_ALSA)
-#include "alsa_midi.h"
-#endif
-
-#if defined(MIDI_MMEAPI)
-#include "mmeapi_midi.h"
-#endif
-
 #include <fmt/format.h>
 
-#include <utility>
+#include <cassert>
 #include <atomic>
 #include <memory>
+#include <utility>
 
 
 static std::unique_ptr<MidiDriver> Driver;
@@ -210,15 +203,10 @@ void Midi::ProcessEvents(MidiHandler* Handler)
 }
 
 
-void Midi::Init()
+void Midi::Init(std::unique_ptr<MidiDriver>&& InDriver)
 {
-#if defined(MIDI_ALSA)
-    Driver = std::make_unique<AlsaMidiDriver>();
-#elif defined(MIDI_MMEAPI)
-    Driver = std::make_unique<MmeApiMidiDriver>();
-#else
-    fmt::println("No MIDI driver is available.");
-#endif
+    assert(InDriver);
+    Driver = std::move(InDriver);
 }
 
 

--- a/mollytime/backend/midi.h
+++ b/mollytime/backend/midi.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <memory>
 #ifdef MIDI_ALSA
 // Polling for MIDI events happens on the audio thread.
 #define MIDI_NEEDS_LOCKS 0
@@ -121,6 +122,6 @@ namespace Midi
     void PatchReset();
     void ReleaseHeldNotes(uint16_t ChannelMask = 0xFFFF);
     void ProcessEvents(MidiHandler* Handler);
-    void Init();
+    void Init(std::unique_ptr<MidiDriver>&& InDriver);
     void Shutdown();
 }

--- a/mollytime/backend/py_api.cpp
+++ b/mollytime/backend/py_api.cpp
@@ -41,6 +41,10 @@
 #include "sdl.h"
 #include "config.h"
 
+#include "alsa_midi.h"
+#include "mmeapi_midi.h"
+#include "stub_midi.h"
+
 #include "jack_stream.h"
 #include "sdl_stream.h"
 #include "stub_stream.h"
@@ -118,6 +122,7 @@ static ColorPoint MakeHSL(float H, float S, float L)
 	return ColorPoint(ColorSpace::HSL, glm::vec3(H, S, L));
 }
 
+
 template<typename T>
 static void BindAudioDriver(py::module_& Module, const std::string_view& ClassName)
 {
@@ -136,6 +141,27 @@ static void BindAudioDriver(py::module_& Module, const std::string_view& ClassNa
             .def_static("get_name", &T::GetName);
     }
 }
+
+
+template<typename T>
+static void BindMidiDriver(py::module_& Module, const std::string_view& ClassName)
+{
+    if constexpr (T::IsAvailable())
+    {
+        py::classh<T, MidiDriver>(Module, ClassName.data())
+            .def(py::init<>())
+            .def_static("is_available", &T::IsAvailable)
+            .def_static("get_name", &T::GetName);
+    }
+    else
+    {
+        class UndefinedPlaceholder { UndefinedPlaceholder(); };
+        py::classh<UndefinedPlaceholder>(Module, ClassName.data())
+            .def_static("is_available", &T::IsAvailable)
+            .def_static("get_name", &T::GetName);
+    }
+}
+
 
 // HACK: Suppress an otherwise-unsuppressable GCC `-pedantic `warning by passing an (unused) value
 // to PYBIND11_MODULE's variadic macro parameter. (If this isn't one of pybind11's defined
@@ -323,6 +349,11 @@ PYBIND11_MODULE(backend, m, 0) {
 	m.def("init_audio", &Audio::Init);
 	m.def("shutdown_audio", &Audio::Shutdown);
 	m.def("get_temporal_pressure", &Audio::GetTemporalPressure);
+
+    py::classh<MidiDriver> _MidiDriver(m, "MidiDriver");
+    BindMidiDriver<AlsaMidiDriver>(m, "AlsaMidiDriver");
+    BindMidiDriver<MmeApiMidiDriver>(m, "MmeApiMidiDriver");
+    BindMidiDriver<StubMidiDriver>(m, "StubMidiDriver");
 
 	m.def("init_midi", &Midi::Init);
 	m.def("shutdown_midi", &Midi::Shutdown);

--- a/mollytime/backend/stub_midi.h
+++ b/mollytime/backend/stub_midi.h
@@ -1,4 +1,3 @@
-
 // Copyright 2025 Aeva Palecek
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,36 +15,18 @@
 #pragma once
 
 #include "midi.h"
-#include <vector>
-#include <cstdint>
 
-
-class MmeApiMidiDriver final : public MidiDriver
+struct StubMidiDriver final : public MidiDriver
 {
-    std::vector<uint32_t> PendingPackets;
-    DECLARE_TRACEABLE_MUTEX(PendingPacketsCrit);
-
-    void CloseInputPort(int Port);
-    bool OpenInputPort(int Port);
-
-public:
-    MmeApiMidiDriver();
-    virtual ~MmeApiMidiDriver() override;
-
     static constexpr bool IsAvailable()
     {
-#if defined(MIDI_MMEAPI)
         return true;
-#else
-        return false;
-#endif
     }
 
     static constexpr std::string_view GetName()
     {
-        return "MmeApi";
+        return "Stub";
     }
 
-    virtual void ProcessEvents(MidiHandler* Handler) override;
-    void NewMidiInputPacket(uint32_t Packet);
+    virtual void ProcessEvents(MidiHandler*) override { }
 };


### PR DESCRIPTION
This follows the approach & rationale of audio driver selection:
- All MIDI drivers are declared in always-available platform-independent headers, but defined only in conditionally-linked implementation files.
- `Midi::Init()` simply asks for an externally-constructed driver, and then takes ownership of it.
- Drivers provide a consistent "static API" that assists high-level code in selecting the appropriate driver to construct.
- All selection logic, logging, etc. is then able to be performed in `__main__.py`, keeping the implementation happily ignorant of such decisionmaking.
- A new command-line argument (`-m` / `--midi-driver`) allows the user to select their favorite driver on startup. If omitted or invalid, a default will be selected.

Unlike audio drivers, MIDI support is optional. So, while I've added a StubMidiDriver, this is only to assist with debugging & implementation of other platforms; an unavailable driver means that the MIDI system will simply remain uninitialized, preserving exisiting behavior.